### PR TITLE
fix in cob_light

### DIFF
--- a/cob_light/ros/src/cob_light.cpp
+++ b/cob_light/ros/src/cob_light.cpp
@@ -203,7 +203,11 @@ class LightControl
 		{
 			char *robot_env;
 			robot_env = getenv("ROBOT");
-			_invertMask = (std::strcmp("raw3-1",robot_env) == 0) ? 1:0;
+			
+			if(robot_env == NULL)
+				ROS_ERROR("Could not get robot environment variable. Is ROBOT env set?");
+			else
+				_invertMask = (std::strcmp("raw3-1",robot_env) == 0) ? 1:0;
 
 			//_nh = ros::NodeHandle("~");
 			_nh.param<std::string>("devicestring",_deviceString,"/dev/ttyLed");


### PR DESCRIPTION
No more crashes, if ROBOT environment variable is not set.
If not set, default care o bot light behavior is used. (no inversion of the rgb values)

Note:
Unclear why ROBOT env is not set, when a node is lauched from a different Machine (PC1 is launching node on PC2)
