### PR TITLE
Correct header path of gtkmm.h

### DIFF
--- a/cob_head_axis/ros/src/cob_head_axis.cpp
+++ b/cob_head_axis/ros/src/cob_head_axis.cpp
@@ -436,8 +436,6 @@ class NodeClass
 				
 						ROS_DEBUG("next point is %d from %d",traj_point_nr_,traj_.points.size());
 						
-						std::cout << fabs( fabs(ActualPos_) - fabs(GoalPos_) ) << std::endl;
-						
 						if (traj_point_nr_ < traj_.points.size())
 						{
 							// if axis is not moving and not reached last point of trajectory, then send new target point

--- a/cob_head_axis/ros/src/cob_head_axis.cpp
+++ b/cob_head_axis/ros/src/cob_head_axis.cpp
@@ -435,7 +435,9 @@ class NodeClass
 						//feedback_.isMoving = false;
 				
 						ROS_DEBUG("next point is %d from %d",traj_point_nr_,traj_.points.size());
-					
+						
+						std::cout << fabs( fabs(ActualPos_) - fabs(GoalPos_) ) << std::endl;
+						
 						if (traj_point_nr_ < traj_.points.size())
 						{
 							// if axis is not moving and not reached last point of trajectory, then send new target point
@@ -449,7 +451,7 @@ class NodeClass
 							//feedback_.pointNr = traj_point_nr;
 							//as_.publishFeedback(feedback_);
 						}
-						else if ( fabs( ActualPos_ - GoalPos_ ) < 0.5*M_PI/180.0 && !finished_ )
+						else if ( fabs( fabs(ActualPos_) - fabs(GoalPos_) ) < 0.5*M_PI/180.0 && !finished_ )
 						{
 							ROS_DEBUG("...reached end of trajectory");
 							finished_ = true;

--- a/cob_lightmode/common/include/spektrumviz.h
+++ b/cob_lightmode/common/include/spektrumviz.h
@@ -55,7 +55,7 @@
 #ifndef SPEKTRUMVIZ_H
 #define SPEKTRUMVIZ_H
 
-#include <gtkmm.h>
+#include <gtkmm-2.4/gtkmm.h>
 #include <beatcontroller.h>
 
 class SpektrumViz : public Gtk::DrawingArea


### PR DESCRIPTION
The header is located under /usr/include/gtkmm-2.4/gtkmm.h (at least under 10.04 and 11.10)

So instead of #include <gtkmm.h> it should be #include <gtkmm-2.4/gtkmm.h>

This fixes the not compiling cob_lightmode package
