### PR TITLE
allow parameterization of timeout for undercarriage_ctrl and velcoity_smoother

### DIFF
--- a/cob_base_velocity_smoother/include/cob_base_velocity_smoother/cob_base_velocity_smoother.h
+++ b/cob_base_velocity_smoother/include/cob_base_velocity_smoother/cob_base_velocity_smoother.h
@@ -92,6 +92,8 @@ private:
   double acc_limit_;
   // ros loop rate (to be loaded from parameter server, otherwise set to default value 30)
   double loop_rate_;
+  // delay between received commands that is allowed. After that, fill buffer with zeros.
+  double max_delay_between_commands_;
   //geometry message filled with zero values
   geometry_msgs::Twist zero_values_;
   // subscribed geometry message

--- a/cob_base_velocity_smoother/src/cob_base_velocity_smoother.cpp
+++ b/cob_base_velocity_smoother/src/cob_base_velocity_smoother.cpp
@@ -134,7 +134,7 @@ cob_base_velocity_smoother::cob_base_velocity_smoother()
 
   if( min_input_rate > loop_rate_)
   {
-    ROS_WARN("min_input_rate > loop_rate: Setting min_input_rate to loop_rate = %d", loop_rate_);
+    ROS_WARN("min_input_rate > loop_rate: Setting min_input_rate to loop_rate = %f", loop_rate_);
     min_input_rate = loop_rate_;
   }
   max_delay_between_commands_ = 1/min_input_rate;

--- a/cob_undercarriage_ctrl/ros/src/cob_undercarriage_ctrl.cpp
+++ b/cob_undercarriage_ctrl/ros/src/cob_undercarriage_ctrl.cpp
@@ -114,7 +114,7 @@ class NodeClass
 		int drive_chain_diagnostic_;		// flag whether base drive chain is operating normal 
 		ros::Time last_time_;				// time Stamp for last odometry measurement
 		ros::Time joint_state_odom_stamp_;	// time stamp of joint states used for current odometry calc
-		double sample_time_;
+		double sample_time_, timeout_;
 		double x_rob_m_, y_rob_m_, theta_rob_rad_; // accumulated motion of robot since startup
     	int iwatchdog_;
     	double 	vel_x_rob_last_, vel_y_rob_last_, vel_theta_rob_last_; //save velocities for better odom calculation
@@ -141,6 +141,23 @@ class NodeClass
 			drive_chain_diagnostic_ = diagnostic_status_lookup_.OK; //WARN; <- THATS FOR DEBUGGING ONLY!
 			
 			// Parameters are set within the launch file
+			// read in timeout for watchdog stopping the controller.
+			if (n.hasParam("timeout"))
+			{
+			  n.getParam("timeout", timeout_);
+			  ROS_INFO("Timeout loaded from Parameter-Server is: %fs", timeout_);
+			}
+			else
+			{
+			  ROS_WARN("No parameter timeout on Parameter-Server. Using default: 1.0s");
+			  timeout_ = 1.0;
+			}
+			if ( timeout_ < sample_time_ )
+			{
+			  ROS_WARN("Specified timeout < sample_time. Setting timeout to sample_time = %fs", sample_time_);
+			  timeout_ = sample_time_;
+			}
+			
 			// Read number of drives from iniFile and pass IniDirectory to CobPlatfCtrl.
 			if (n.hasParam("IniDirectory"))
 			{
@@ -527,7 +544,7 @@ void NodeClass::CalcCtrlStep()
 		k = 0;
 		for(int i = 0; i<m_iNumJoints; i++)
 		{
-			if(iwatchdog_ < 50)
+			if(iwatchdog_ < (int) std::floor(timeout_/sample_time_) )
 			{
 				// for steering motors
 				if( i == 1 || i == 3 || i == 5 || i == 7) // ToDo: specify this via the Msg


### PR DESCRIPTION
This hopefully solves the problem experienced with cob4.

I tried to reproduce the same behaviour on cob3-3. It is not really clear to me, what causes it.

What I found is that it needs several things to be fulfilled:
1. no footprint_observer running
2. you need to press both the deadman-button as well as the "upper_neck" button for bypassing the emergency stop. Then, you need to let go of the upper_neck button and shortly after that (actually almost at the same time)  let go of the deadman-button. Then, no zero velocities are sent and thus the base drives until the watchdogs recognize this and stop the robot

This Pull-Request now lets you specify the time after which the watchdogs stop the robot. 
