### PR TITLE
Base struc

### DIFF
--- a/cob_base_drive_chain/CMakeLists.txt
+++ b/cob_base_drive_chain/CMakeLists.txt
@@ -32,12 +32,15 @@ rosbuild_gensrv()
 # add include search paths
 INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/common/include)
 
+# add include search paths
+INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/ros/include)
+
 # add project libs
 rosbuild_add_library(${PROJECT_NAME} common/src/CanCtrlPltfCOb3.cpp)
 
 # add executable
-rosbuild_add_executable(${PROJECT_NAME}_node ros/src/${PROJECT_NAME}.cpp)
-rosbuild_add_executable(${PROJECT_NAME}_sim_node ros/src/${PROJECT_NAME}.cpp)
+rosbuild_add_executable(${PROJECT_NAME}_node ros/src/${PROJECT_NAME}.cpp ros/src/${PROJECT_NAME}_param_loader.cpp)
+rosbuild_add_executable(${PROJECT_NAME}_sim_node ros/src/${PROJECT_NAME}.cpp ros/src/${PROJECT_NAME}_param_loader.cpp)
 rosbuild_add_compile_flags(${PROJECT_NAME}_sim_node -D__SIM__)
 #rosbuild_add_executable(cob_base_drive_chain_sim ros/src/base_drive_chain_sim.cpp)
 

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
@@ -66,6 +66,9 @@
 #include <cob_canopen_motor/CanDriveHarmonica.h>
 #include <cob_generic_can/CanItf.h>
 
+#include <cob_base_drive_chain/CanCtrlPltfTypes.h>
+#include <cob_base_drive_chain/PlatformParams.h>
+
 // Headers provided by cob-packages which should be avoided/removed
 #include <cob_utilities/IniFile.h>
 #include <cob_utilities/Mutex.h>
@@ -88,7 +91,7 @@ public:
 	/** 
 	 * Default constructor.
 	 */
-	CanCtrlPltfCOb3(std::string iniDirectory);
+	CanCtrlPltfCOb3(std::string iniDirectory, PlatformParams platform_parameters);
 
 	/**
 	 * Default destructor.
@@ -256,6 +259,7 @@ protected:
 	 */
 	std::string sIniDirectory;
 	std::string sComposed;
+	PlatformParams m_PlatformParams;
 	void readConfiguration();
 
 	/**
@@ -269,155 +273,7 @@ protected:
 	/**
 	 * Parameters of the class CanCtrlPltfCOb3.
 	 */
-	struct ParamType
-	{
-		// Platform config
 
-		int iHasWheel1DriveMotor;
-		int iHasWheel1SteerMotor;
-		int iHasWheel2DriveMotor;
-		int iHasWheel2SteerMotor;
-		int iHasWheel3DriveMotor;
-		int iHasWheel3SteerMotor;
-		int iHasWheel4DriveMotor;
-		int iHasWheel4SteerMotor;
-
-		double dWheel1SteerDriveCoupling;
-		double dWheel2SteerDriveCoupling;
-		double dWheel3SteerDriveCoupling;
-		double dWheel4SteerDriveCoupling;
-
-		int iRadiusWheelMM;
-		int iDistSteerAxisToDriveWheelMM;
-
-		int iHasRelayBoard;
-		int iHasIOBoard;
-		int iHasUSBoard;
-		int iHasGyroBoard;
-		int iHasRadarBoard;
-
-		double dCanTimeout;
-	};
-
-	/**
-	 * Parameters charaterising combination of gears and drives
-	 */
-	struct GearMotorParamType
-	{
-		int		iEncIncrPerRevMot;
-		double	dVelMeasFrqHz;
-		double	dGearRatio;
-		double	dBeltRatio;
-		int		iSign;
-		double	dVelMaxEncIncrS;
-		double	dAccIncrS2;
-		double	dDecIncrS2;
-		double	dScaleToMM;
-		int	iEncOffsetIncr;
-		bool	bIsSteer;
-		double  dCurrentToTorque;
-		double  dCurrMax;
-		int 	iHomingDigIn;
-	};
-
-	/**
-	 * CAN IDs for Neobotix boards. (Default Values)
-	 */
-	struct CanNeoIDType
-	{
-		int IOBoard_rx_ID;
-		int IOBoard_tx_ID;
-
-		int DriveNeo_W1Drive_rx_ID;
-		int DriveNeo_W1Drive_tx_ID;
-		int DriveNeo_W1Steer_rx_ID;
-		int DriveNeo_W1Steer_tx_ID;
-
-		int DriveNeo_W2Drive_rx_ID;
-		int DriveNeo_W2Drive_tx_ID;
-		int DriveNeo_W2Steer_rx_ID;
-		int DriveNeo_W2Steer_tx_ID;
-
-		int DriveNeo_W3Drive_rx_ID;
-		int DriveNeo_W3Drive_tx_ID;
-		int DriveNeo_W3Steer_rx_ID;
-		int DriveNeo_W3Steer_tx_ID;
-
-		int DriveNeo_W4Drive_rx_ID;
-		int DriveNeo_W4Drive_tx_ID;
-		int DriveNeo_W4Steer_rx_ID;
-		int DriveNeo_W4Steer_tx_ID;
-
-		int USBoard_rx_ID;
-		int USBoard_tx_ID;
-		int GyroBoard_rx_ID;
-		int GyroBoard_tx_ID;
-		int RadarBoard_rx_ID;
-		int RadarBoard_tx_ID;
-	};
-
-	/**
-	 * CAN IDs for motor drive Harmonica.
-	 * (actually this should be read from inifile)
-	 */
-	struct CanOpenIDType
-	{	
-		// Wheel 1
-		// can adresse motor 1
-		int TxPDO1_W1Drive;
-		int TxPDO2_W1Drive;
-		int RxPDO2_W1Drive;
-		int TxSDO_W1Drive;
-		int RxSDO_W1Drive;
-		// can adresse motor 2
-		int TxPDO1_W1Steer;
-		int TxPDO2_W1Steer;
-		int RxPDO2_W1Steer;
-		int TxSDO_W1Steer;
-		int RxSDO_W1Steer;
-
-		// Wheel 2
-		// can adresse motor 7
-		int TxPDO1_W2Drive;
-		int TxPDO2_W2Drive;
-		int RxPDO2_W2Drive;
-		int TxSDO_W2Drive;
-		int RxSDO_W2Drive;
-		// can adresse motor 8
-		int TxPDO1_W2Steer;
-		int TxPDO2_W2Steer;
-		int RxPDO2_W2Steer;
-		int TxSDO_W2Steer;
-		int RxSDO_W2Steer;	
-		
-		// Wheel 3
-		// can adresse motor 5
-		int TxPDO1_W3Drive;
-		int TxPDO2_W3Drive;
-		int RxPDO2_W3Drive;
-		int TxSDO_W3Drive;
-		int RxSDO_W3Drive;
-		// can adresse motor 6
-		int TxPDO1_W3Steer;
-		int TxPDO2_W3Steer;
-		int RxPDO2_W3Steer;
-		int TxSDO_W3Steer;
-		int RxSDO_W3Steer;
-		
-		// Wheel 4
-		// can adresse motor 3
-		int TxPDO1_W4Drive;
-		int TxPDO2_W4Drive;
-		int RxPDO2_W4Drive;
-		int TxSDO_W4Drive;
-		int RxSDO_W4Drive;
-		// can adresse motor 4
-		int TxPDO1_W4Steer;
-		int TxPDO2_W4Steer;
-		int RxPDO2_W4Steer;
-		int TxSDO_W4Steer;
-		int RxSDO_W4Steer;	
-	};
 
 	//--------------------------------- Parameter
 	ParamType m_Param;

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
@@ -70,12 +70,7 @@
 #include <cob_base_drive_chain/PlatformParams.h>
 
 // Headers provided by cob-packages which should be avoided/removed
-#include <cob_utilities/IniFile.h>
 #include <cob_utilities/Mutex.h>
-
-// remove (not supported)
-//#include "stdafx.h"
-
 
 //-----------------------------------------------
 
@@ -257,8 +252,6 @@ protected:
 	 * Reads configuration of can node and components from Inifile
 	 * (should be adapted to use ROS-Parameter file)
 	 */
-	std::string sIniDirectory;
-	std::string sComposed;
 	PlatformParams m_PlatformParams;
 	void readConfiguration();
 
@@ -267,28 +260,9 @@ protected:
 	 */
 	void sendNetStartCanOpen();
 
-
-	//--------------------------------- Types
-	
-	/**
-	 * Parameters of the class CanCtrlPltfCOb3.
-	 */
-
-
 	//--------------------------------- Parameter
-	// ParamType m_Param;
-//	CanNeoIDType m_CanNeoIDParam;
 	CanOpenIDType m_CanOpenIDParam;
 
-	// Prms for all Motor/Gear combos
-	GearMotorParamType m_GearMotDrive1;
-	GearMotorParamType m_GearMotDrive2;
-	GearMotorParamType m_GearMotDrive3;
-	GearMotorParamType m_GearMotDrive4;	
-	GearMotorParamType m_GearMotSteer1;
-	GearMotorParamType m_GearMotSteer2;
-	GearMotorParamType m_GearMotSteer3;
-	GearMotorParamType m_GearMotSteer4;
 
 	//--------------------------------- Variables
 	CanMsg m_CanMsgRec;
@@ -298,7 +272,6 @@ protected:
 	//--------------------------------- Components
 	// Can-Interface
 	CanItf* m_pCanCtrl;
-	IniFile m_IniFile;
 
 	int m_iNumMotors;
 	int m_iNumDrives;
@@ -306,13 +279,7 @@ protected:
 	// Motor-Controllers
 	// pointer to each motors Can-Itf
 	std::vector<CanDriveItf*> m_vpMotor;
-	// vector with enums (specifying hardware-structure) -> simplifies cmd-check
-	// this has to be adapted in c++ file to your hardware
 	std::vector<int> m_viMotorID;
-
-	// other
-
-
 };
 
 

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
@@ -276,7 +276,7 @@ protected:
 
 
 	//--------------------------------- Parameter
-	ParamType m_Param;
+	// ParamType m_Param;
 //	CanNeoIDType m_CanNeoIDParam;
 	CanOpenIDType m_CanOpenIDParam;
 
@@ -304,14 +304,6 @@ protected:
 	int m_iNumDrives;
 
 	// Motor-Controllers
-/*	CanDriveItf* m_pW1DriveMotor;
-	CanDriveItf* m_pW1SteerMotor;
-	CanDriveItf* m_pW2DriveMotor;
-	CanDriveItf* m_pW2SteerMotor;
-	CanDriveItf* m_pW3DriveMotor;
-	CanDriveItf* m_pW3SteerMotor;
-	CanDriveItf* m_pW4DriveMotor;
-	CanDriveItf* m_pW4SteerMotor;*/
 	// pointer to each motors Can-Itf
 	std::vector<CanDriveItf*> m_vpMotor;
 	// vector with enums (specifying hardware-structure) -> simplifies cmd-check

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfCOb3.h
@@ -91,7 +91,7 @@ public:
 	/** 
 	 * Default constructor.
 	 */
-	CanCtrlPltfCOb3(std::string iniDirectory, PlatformParams platform_parameters);
+	CanCtrlPltfCOb3(PlatformParams platform_parameters);
 
 	/**
 	 * Default destructor.

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfTypes.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfTypes.h
@@ -1,0 +1,209 @@
+/****************************************************************
+ *
+ * Copyright (c) 2010
+ *
+ * Fraunhofer Institute for Manufacturing Engineering	
+ * and Automation (IPA)
+ *
+ * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ *
+ * Project name: care-o-bot
+ * ROS stack name: cob_drivers
+ * ROS package name: cob_base_drive_chain
+ * Description: This is a sample implementation of a can-bus with several nodes. In this case it implements the drive-chain of the Care-O-bot3 mobile base. yet, this can be used as template for using the generic_can and canopen_motor packages to implement arbitrary can-setups.
+ *								
+ * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ *			
+ * Author: Christian Connette, email:christian.connette@ipa.fhg.de
+ * Supervised by: Christian Connette, email:christian.connette@ipa.fhg.de
+ *
+ * Date of creation: Feb 2010
+ * ToDo: 
+ *
+ * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Fraunhofer Institute for Manufacturing 
+ *       Engineering and Automation (IPA) nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License LGPL as 
+ * published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License LGPL for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public 
+ * License LGPL along with this program. 
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ ****************************************************************/
+
+#ifndef CANCTRLPLTFTYPES_INCLUDEDEF_H
+#define CANCTRLPLTFTYPES_INCLUDEDEF_H
+
+
+
+struct ParamType
+{
+	// Platform config
+
+	int iHasWheel1DriveMotor;
+	int iHasWheel1SteerMotor;
+	int iHasWheel2DriveMotor;
+	int iHasWheel2SteerMotor;
+	int iHasWheel3DriveMotor;
+	int iHasWheel3SteerMotor;
+	int iHasWheel4DriveMotor;
+	int iHasWheel4SteerMotor;
+
+	double dWheel1SteerDriveCoupling;
+	double dWheel2SteerDriveCoupling;
+	double dWheel3SteerDriveCoupling;
+	double dWheel4SteerDriveCoupling;
+
+	int iRadiusWheelMM;
+	int iDistSteerAxisToDriveWheelMM;
+
+	int iHasRelayBoard;
+	int iHasIOBoard;
+	int iHasUSBoard;
+	int iHasGyroBoard;
+	int iHasRadarBoard;
+
+	double dCanTimeout;
+};
+
+/**
+ * Parameters charaterising combination of gears and drives
+ */
+struct GearMotorParamType
+{
+	int		iEncIncrPerRevMot;
+	double	dVelMeasFrqHz;
+	double	dGearRatio;
+	double	dBeltRatio;
+	int		iSign;
+	double	dVelMaxEncIncrS;
+	double	dAccIncrS2;
+	double	dDecIncrS2;
+	double	dScaleToMM;
+	int		iEncOffsetIncr;
+	bool	bIsSteer;
+	double  dCurrentToTorque;
+	double  dCurrMax;
+	int 	iHomingDigIn;
+};
+
+/**
+ * CAN IDs for Neobotix boards. (Default Values)
+ */
+struct CanNeoIDType
+{
+	int IOBoard_rx_ID;
+	int IOBoard_tx_ID;
+
+	int DriveNeo_W1Drive_rx_ID;
+	int DriveNeo_W1Drive_tx_ID;
+	int DriveNeo_W1Steer_rx_ID;
+	int DriveNeo_W1Steer_tx_ID;
+
+	int DriveNeo_W2Drive_rx_ID;
+	int DriveNeo_W2Drive_tx_ID;
+	int DriveNeo_W2Steer_rx_ID;
+	int DriveNeo_W2Steer_tx_ID;
+
+	int DriveNeo_W3Drive_rx_ID;
+	int DriveNeo_W3Drive_tx_ID;
+	int DriveNeo_W3Steer_rx_ID;
+	int DriveNeo_W3Steer_tx_ID;
+
+	int DriveNeo_W4Drive_rx_ID;
+	int DriveNeo_W4Drive_tx_ID;
+	int DriveNeo_W4Steer_rx_ID;
+	int DriveNeo_W4Steer_tx_ID;
+
+	int USBoard_rx_ID;
+	int USBoard_tx_ID;
+	int GyroBoard_rx_ID;
+	int GyroBoard_tx_ID;
+	int RadarBoard_rx_ID;
+	int RadarBoard_tx_ID;
+};
+
+/**
+ * CAN IDs for motor drive Harmonica.
+ * (actually this should be read from inifile)
+ */
+struct CanOpenIDType
+{	
+	// Wheel 1
+	// can adresse motor 1
+	int TxPDO1_W1Drive;
+	int TxPDO2_W1Drive;
+	int RxPDO2_W1Drive;
+	int TxSDO_W1Drive;
+	int RxSDO_W1Drive;
+	// can adresse motor 2
+	int TxPDO1_W1Steer;
+	int TxPDO2_W1Steer;
+	int RxPDO2_W1Steer;
+	int TxSDO_W1Steer;
+	int RxSDO_W1Steer;
+
+	// Wheel 2
+	// can adresse motor 7
+	int TxPDO1_W2Drive;
+	int TxPDO2_W2Drive;
+	int RxPDO2_W2Drive;
+	int TxSDO_W2Drive;
+	int RxSDO_W2Drive;
+	// can adresse motor 8
+	int TxPDO1_W2Steer;
+	int TxPDO2_W2Steer;
+	int RxPDO2_W2Steer;
+	int TxSDO_W2Steer;
+	int RxSDO_W2Steer;	
+	
+	// Wheel 3
+	// can adresse motor 5
+	int TxPDO1_W3Drive;
+	int TxPDO2_W3Drive;
+	int RxPDO2_W3Drive;
+	int TxSDO_W3Drive;
+	int RxSDO_W3Drive;
+	// can adresse motor 6
+	int TxPDO1_W3Steer;
+	int TxPDO2_W3Steer;
+	int RxPDO2_W3Steer;
+	int TxSDO_W3Steer;
+	int RxSDO_W3Steer;
+	
+	// Wheel 4
+	// can adresse motor 3
+	int TxPDO1_W4Drive;
+	int TxPDO2_W4Drive;
+	int RxPDO2_W4Drive;
+	int TxSDO_W4Drive;
+	int RxSDO_W4Drive;
+	// can adresse motor 4
+	int TxPDO1_W4Steer;
+	int TxPDO2_W4Steer;
+	int RxPDO2_W4Steer;
+	int TxSDO_W4Steer;
+	int RxSDO_W4Steer;	
+};
+
+#endif

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfTypes.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/CanCtrlPltfTypes.h
@@ -76,13 +76,15 @@ struct ParamType
 
 	int iRadiusWheelMM;
 	int iDistSteerAxisToDriveWheelMM;
-
+	
+	/*
 	int iHasRelayBoard;
 	int iHasIOBoard;
 	int iHasUSBoard;
 	int iHasGyroBoard;
 	int iHasRadarBoard;
-
+	*/	
+	
 	double dCanTimeout;
 };
 

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/PlatformParams.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/PlatformParams.h
@@ -57,29 +57,34 @@
 //-----------------------------------------------
 
 // general includes
+#include <vector>
 #include <cob_base_drive_chain/CanCtrlPltfTypes.h>
 #include <cob_generic_can/CanDeviceParams.h>
-#include <cob_canopen_motor/DriveParams.h>
+#include <cob_canopen_motor/DriveParam.h>
 
 class PlatformParams {
 public:
-	PlatformParams();
-	~PlatformParams();
+	PlatformParams() {};
+	~PlatformParams() {};
 	
+	//CAN-device parameters
 	CanDeviceParams can_device_params;
 	
+	
+	//general parameters
+	int num_wheels;
+	double max_drive_rate_rad_s; 
+	double max_steer_rate_rad_s; 
+		
+	ParamType platform_config;
+	
+	//parameters for each wheel	
 	CanOpenIDType canopen_ids;
 	
-	DriveParam drive_param_w1_drive;
-	DriveParam drive_param_w1_steer;
-	DriveParam drive_param_w2_drive;
-	DriveParam drive_param_w2_steer;
-	DriveParam drive_param_w3_drive;
-	DriveParam drive_param_w3_steer;
-	DriveParam drive_param_w4_drive;
-	DriveParam drive_param_w4_steer;
-	
-	
+	std::vector<GearMotorParamType> drive_param_drive;
+	std::vector<GearMotorParamType> drive_param_steer;
+	std::vector<double> steer_drive_coupling;
+	std::vector<double> wheel_neutral_pos;
 };
 #endif
 

--- a/cob_base_drive_chain/common/include/cob_base_drive_chain/PlatformParams.h
+++ b/cob_base_drive_chain/common/include/cob_base_drive_chain/PlatformParams.h
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- * Copyright (c) 2010
+ * Copyright (c) 2012
  *
  * Fraunhofer Institute for Manufacturing Engineering	
  * and Automation (IPA)
@@ -9,16 +9,16 @@
  *
  * Project name: care-o-bot
  * ROS stack name: cob_drivers
- * ROS package name: cob_generic_can
- * Description:
+ * ROS package name: cob_base_drive_chain
+ * Description: This is a sample implementation of a can-bus with several nodes. In this case it implements the drive-chain of the Care-O-bot3 mobile base. yet, this can be used as template for using the generic_can and canopen_motor packages to implement arbitrary can-setups.
  *								
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *			
- * Author: Christian Connette, email:christian.connette@ipa.fhg.de
+ * Author: Philipp Koehler
  * Supervised by: Christian Connette, email:christian.connette@ipa.fhg.de
  *
- * Date of creation: Feb 2009
- * ToDo: Remove dependency to inifiles_old -> Inifile.h
+ * Date of creation: Jan 2012
+ * ToDo:
  *
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
@@ -51,44 +51,36 @@
  *
  ****************************************************************/
 
-#ifndef CANPEAKSYSUSB_INCLUDEDEF_H
-#define CANPEAKSYSUSB_INCLUDEDEF_H
+#ifndef PLATFORMPARAMS_INCLUDEDEF_H
+#define PLATFORMPARAMS_INCLUDEDEF_H
+
 //-----------------------------------------------
-#include <cob_generic_can/CanItf.h>
+
+// general includes
+#include <cob_base_drive_chain/CanCtrlPltfTypes.h>
 #include <cob_generic_can/CanDeviceParams.h>
-#include <libpcan/libpcan.h>
+#include <cob_canopen_motor/DriveParams.h>
 
-//-----------------------------------------------
-
-class CANPeakSysUSB : public CanItf
-{
+class PlatformParams {
 public:
-	// --------------- Interface
-	CANPeakSysUSB(CanDeviceParams can_device_params);
-	~CANPeakSysUSB();
-	void init();
-	void destroy() {};
-	bool transmitMsg(CanMsg CMsg, bool bBlocking = true);
-	bool receiveMsg(CanMsg* pCMsg);
-	bool receiveMsgRetry(CanMsg* pCMsg, int iNrOfRetry);
-	bool isObjectMode() { return false; }
-
-private:
-	// --------------- Types
-	HANDLE m_handle;
+	PlatformParams();
+	~PlatformParams();
 	
-	bool m_bInitialized;
-	std::string m_sDevicePath;
-	bool m_bSimuEnabled;
-	int m_iBaudrateVal;
-
-	static const int c_iInterrupt;
-	static const int c_iPort;
+	CanDeviceParams can_device_params;
 	
-	bool initCAN();
+	CanOpenIDType canopen_ids;
 	
-	void outputDetailedStatus();
+	DriveParam drive_param_w1_drive;
+	DriveParam drive_param_w1_steer;
+	DriveParam drive_param_w2_drive;
+	DriveParam drive_param_w2_steer;
+	DriveParam drive_param_w3_drive;
+	DriveParam drive_param_w3_steer;
+	DriveParam drive_param_w4_drive;
+	DriveParam drive_param_w4_steer;
+	
+	
 };
-//-----------------------------------------------
 #endif
+
 

--- a/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
+++ b/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
@@ -66,17 +66,23 @@
 
 //-----------------------------------------------
 
-CanCtrlPltfCOb3::CanCtrlPltfCOb3(std::string iniDirectory,PlatformParams platform_parameters)
+CanCtrlPltfCOb3::CanCtrlPltfCOb3(PlatformParams platform_parameters)
 {	
-	sIniDirectory = iniDirectory;
+	//sIniDirectory = iniDirectory;
 	m_PlatformParams = platform_parameters;
-	
+
+
+	/*	
 	IniFile iniFile;
 	iniFile.SetFileName(sIniDirectory + "Platform.ini", "PltfHardwareCoB3.h");
 
 	// get max Joint-Velocities (in rad/s) for Steer- and Drive-Joint
 	iniFile.GetKeyInt("Config", "NumberOfMotors", &m_iNumMotors, true);
 	iniFile.GetKeyInt("Config", "NumberOfWheels", &m_iNumDrives, true);
+	*/
+	
+	m_iNumDrives = m_PlatformParams.num_wheels;
+	m_iNumMotors = m_iNumDrives * 2;
 
 	if(m_iNumMotors < 2 || m_iNumMotors > 8) {
 		m_iNumMotors = 8;
@@ -115,8 +121,9 @@ CanCtrlPltfCOb3::CanCtrlPltfCOb3(std::string iniDirectory,PlatformParams platfor
 		m_viMotorID[7] = CANNODE_WHEEL4STEERMOTOR;
 
 	// ------------- parameters
-	m_Param.dCanTimeout = 7;
+	m_Param.dCanTimeout = m_PlatformParams.platform_config.dCanTimeout;
 
+	/*
 	if(m_iNumMotors >= 1)
 		m_Param.iHasWheel1DriveMotor = 0;
 	if(m_iNumMotors >= 2)
@@ -133,18 +140,20 @@ CanCtrlPltfCOb3::CanCtrlPltfCOb3(std::string iniDirectory,PlatformParams platfor
 		m_Param.iHasWheel4DriveMotor = 0;
 	if(m_iNumMotors == 8)
 		m_Param.iHasWheel4SteerMotor = 0;
-
+	*/
+	
+	/*
 	m_Param.iHasRelayBoard = 0;
 	m_Param.iHasIOBoard = 0;
 	m_Param.iHasUSBoard = 0;
 	m_Param.iHasGyroBoard = 0;
 	m_Param.iHasRadarBoard = 0;	
+	*/
 
 	m_bWatchdogErr = false;
 	
-	// ------------ CanIds
-	
-	// ------------ For CanOpen (Harmonica)
+	/*
+	// ------------ Default CAN-IDs for CanOpen (Harmonica)
 	// Wheel 1
 	// can adresse motor 1
 	if(m_iNumMotors >= 1)
@@ -221,6 +230,7 @@ CanCtrlPltfCOb3::CanCtrlPltfCOb3(std::string iniDirectory,PlatformParams platfor
 		m_CanOpenIDParam.TxSDO_W4Steer = 0x585;
 		m_CanOpenIDParam.RxSDO_W4Steer = 0x605;
 	}
+	*/
 }
 
 //-----------------------------------------------
@@ -261,10 +271,9 @@ void CanCtrlPltfCOb3::readConfiguration()
 	std::string strTypeDrive;
 	std::string strTypeSteer;
 
-	double dScaleToMM;
+	//double dScaleToMM;
 	
 	m_pCanCtrl = new CANPeakSysUSB(m_PlatformParams.can_device_params);
-	
 	/*
 	// read CanCtrl.ini
 	m_IniFile.SetFileName(sIniDirectory + "CanCtrl.ini", "CanCtrlPltfCOb3.cpp");
@@ -311,8 +320,11 @@ void CanCtrlPltfCOb3::readConfiguration()
 	if(m_iNumDrives == 4)
 		m_IniFile.GetKeyDouble("DrivePrms", "Wheel4SteerDriveCoupling", &m_Param.dWheel4SteerDriveCoupling, true);
 
-
-	// CanOpenId's ----- Default values (DESIRE)
+	
+	// CanOpenId's
+	m_CanOpenIDParam = m_PlatformParams.canopen_ids;
+	
+	/*
 	// Wheel 1
 	// DriveMotor
 	if(m_iNumDrives >= 1)
@@ -392,6 +404,7 @@ void CanCtrlPltfCOb3::readConfiguration()
 		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W4Steer", &m_CanOpenIDParam.TxSDO_W4Steer, true);
 		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W4Steer", &m_CanOpenIDParam.RxSDO_W4Steer, true);
 	}
+	*/
 
 	// read configuration of the Drives (CanCtrl.ini)
 	/* Drivemotor1-Parameters Old
@@ -407,6 +420,7 @@ void CanCtrlPltfCOb3::readConfiguration()
 	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "EncOffsetIncr",&(m_GearMotDrive1.iEncOffsetIncr),true);
 	*/
 
+	/*
 	// "Drive Motor Type1" drive parameters	
 	if(m_iNumDrives >= 1)
 	{
@@ -555,167 +569,167 @@ void CanCtrlPltfCOb3::readConfiguration()
 	{
 		DriveParamW1DriveMotor.setParam(
 			0,
-			m_GearMotDrive1.iEncIncrPerRevMot,
-			m_GearMotDrive1.dVelMeasFrqHz,
-			m_GearMotDrive1.dBeltRatio,
-			m_GearMotDrive1.dGearRatio,
-			m_GearMotDrive1.iSign,
-			m_GearMotDrive1.dVelMaxEncIncrS,
-			m_GearMotDrive1.dAccIncrS2,
-			m_GearMotDrive1.dDecIncrS2,
-			m_GearMotDrive1.iEncOffsetIncr,
-			m_GearMotDrive1.bIsSteer,
-			m_GearMotDrive1.dCurrentToTorque,
-			m_GearMotDrive1.dCurrMax,
-			m_GearMotDrive1.iHomingDigIn);
+			m_PlatformParams.drive_param_drive.at(0).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_drive.at(0).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_drive.at(0).dBeltRatio,
+			m_PlatformParams.drive_param_drive.at(0).dGearRatio,
+			m_PlatformParams.drive_param_drive.at(0).iSign,
+			m_PlatformParams.drive_param_drive.at(0).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_drive.at(0).dAccIncrS2,
+			m_PlatformParams.drive_param_drive.at(0).dDecIncrS2,
+			m_PlatformParams.drive_param_drive.at(0).iEncOffsetIncr,
+			m_PlatformParams.drive_param_drive.at(0).bIsSteer,
+			m_PlatformParams.drive_param_drive.at(0).dCurrentToTorque,
+			m_PlatformParams.drive_param_drive.at(0).dCurrMax,
+			m_PlatformParams.drive_param_drive.at(0).iHomingDigIn);
 	}
 	
 	if(m_iNumDrives >= 1)
 	{
 		DriveParamW1SteerMotor.setParam(
 			1,
-			m_GearMotSteer1.iEncIncrPerRevMot,
-			m_GearMotSteer1.dVelMeasFrqHz,
-			m_GearMotSteer1.dBeltRatio,
-			m_GearMotSteer1.dGearRatio,
-			m_GearMotSteer1.iSign,
-			m_GearMotSteer1.dVelMaxEncIncrS,
-			m_GearMotSteer1.dAccIncrS2,
-			m_GearMotSteer1.dDecIncrS2,
-			m_GearMotSteer1.iEncOffsetIncr,
-			m_GearMotSteer1.bIsSteer,
-			m_GearMotSteer1.dCurrentToTorque,
-			m_GearMotSteer1.dCurrMax,
-			m_GearMotSteer1.iHomingDigIn);
+			m_PlatformParams.drive_param_steer.at(0).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_steer.at(0).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_steer.at(0).dBeltRatio,
+			m_PlatformParams.drive_param_steer.at(0).dGearRatio,
+			m_PlatformParams.drive_param_steer.at(0).iSign,
+			m_PlatformParams.drive_param_steer.at(0).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_steer.at(0).dAccIncrS2,
+			m_PlatformParams.drive_param_steer.at(0).dDecIncrS2,
+			m_PlatformParams.drive_param_steer.at(0).iEncOffsetIncr,
+			m_PlatformParams.drive_param_steer.at(0).bIsSteer,
+			m_PlatformParams.drive_param_steer.at(0).dCurrentToTorque,
+			m_PlatformParams.drive_param_steer.at(0).dCurrMax,
+			m_PlatformParams.drive_param_steer.at(0).iHomingDigIn);
 	}
 
 	if(m_iNumDrives >= 2)
 	{
 		DriveParamW2DriveMotor.setParam(
 			2,
-			m_GearMotDrive2.iEncIncrPerRevMot,
-			m_GearMotDrive2.dVelMeasFrqHz,
-			m_GearMotDrive2.dBeltRatio,
-			m_GearMotDrive2.dGearRatio,
-			m_GearMotDrive2.iSign,
-			m_GearMotDrive2.dVelMaxEncIncrS,
-			m_GearMotDrive2.dAccIncrS2,
-			m_GearMotDrive2.dDecIncrS2,
-			m_GearMotDrive2.iEncOffsetIncr,
-			m_GearMotDrive2.bIsSteer,
-			m_GearMotDrive2.dCurrentToTorque,
-			m_GearMotDrive2.dCurrMax,
-			m_GearMotDrive2.iHomingDigIn);
+			m_PlatformParams.drive_param_drive.at(1).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_drive.at(1).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_drive.at(1).dBeltRatio,
+			m_PlatformParams.drive_param_drive.at(1).dGearRatio,
+			m_PlatformParams.drive_param_drive.at(1).iSign,
+			m_PlatformParams.drive_param_drive.at(1).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_drive.at(1).dAccIncrS2,
+			m_PlatformParams.drive_param_drive.at(1).dDecIncrS2,
+			m_PlatformParams.drive_param_drive.at(1).iEncOffsetIncr,
+			m_PlatformParams.drive_param_drive.at(1).bIsSteer,
+			m_PlatformParams.drive_param_drive.at(1).dCurrentToTorque,
+			m_PlatformParams.drive_param_drive.at(1).dCurrMax,
+			m_PlatformParams.drive_param_drive.at(1).iHomingDigIn);
 	}
 	
 	if(m_iNumDrives >= 2)
 	{
 		DriveParamW2SteerMotor.setParam(
 			3,
-			m_GearMotSteer2.iEncIncrPerRevMot,
-			m_GearMotSteer2.dVelMeasFrqHz,
-			m_GearMotSteer2.dBeltRatio,
-			m_GearMotSteer2.dGearRatio,
-			m_GearMotSteer2.iSign,
-			m_GearMotSteer2.dVelMaxEncIncrS,
-			m_GearMotSteer2.dAccIncrS2,
-			m_GearMotSteer2.dDecIncrS2,
-			m_GearMotSteer2.iEncOffsetIncr,
-			m_GearMotSteer2.bIsSteer,
-			m_GearMotSteer2.dCurrentToTorque,
-			m_GearMotSteer2.dCurrMax,
-			m_GearMotSteer2.iHomingDigIn);
+			m_PlatformParams.drive_param_steer.at(1).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_steer.at(1).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_steer.at(1).dBeltRatio,
+			m_PlatformParams.drive_param_steer.at(1).dGearRatio,
+			m_PlatformParams.drive_param_steer.at(1).iSign,
+			m_PlatformParams.drive_param_steer.at(1).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_steer.at(1).dAccIncrS2,
+			m_PlatformParams.drive_param_steer.at(1).dDecIncrS2,
+			m_PlatformParams.drive_param_steer.at(1).iEncOffsetIncr,
+			m_PlatformParams.drive_param_steer.at(1).bIsSteer,
+			m_PlatformParams.drive_param_steer.at(1).dCurrentToTorque,
+			m_PlatformParams.drive_param_steer.at(1).dCurrMax,
+			m_PlatformParams.drive_param_steer.at(1).iHomingDigIn);
 	}
 
 	if(m_iNumDrives >= 3)
 	{
 		DriveParamW3DriveMotor.setParam(
 			4,
-			m_GearMotDrive3.iEncIncrPerRevMot,
-			m_GearMotDrive3.dVelMeasFrqHz,
-			m_GearMotDrive3.dBeltRatio,
-			m_GearMotDrive3.dGearRatio,
-			m_GearMotDrive3.iSign,
-			m_GearMotDrive3.dVelMaxEncIncrS,
-			m_GearMotDrive3.dAccIncrS2,
-			m_GearMotDrive3.dDecIncrS2,
-			m_GearMotDrive3.iEncOffsetIncr,
-			m_GearMotDrive3.bIsSteer,
-			m_GearMotDrive3.dCurrentToTorque,
-			m_GearMotDrive3.dCurrMax,
-			m_GearMotDrive3.iHomingDigIn);
+			m_PlatformParams.drive_param_drive.at(2).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_drive.at(2).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_drive.at(2).dBeltRatio,
+			m_PlatformParams.drive_param_drive.at(2).dGearRatio,
+			m_PlatformParams.drive_param_drive.at(2).iSign,
+			m_PlatformParams.drive_param_drive.at(2).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_drive.at(2).dAccIncrS2,
+			m_PlatformParams.drive_param_drive.at(2).dDecIncrS2,
+			m_PlatformParams.drive_param_drive.at(2).iEncOffsetIncr,
+			m_PlatformParams.drive_param_drive.at(2).bIsSteer,
+			m_PlatformParams.drive_param_drive.at(2).dCurrentToTorque,
+			m_PlatformParams.drive_param_drive.at(2).dCurrMax,
+			m_PlatformParams.drive_param_drive.at(2).iHomingDigIn);
 	}
 	
 	if(m_iNumDrives >= 3)
 	{
 		DriveParamW3SteerMotor.setParam(
 			5,
-			m_GearMotSteer3.iEncIncrPerRevMot,
-			m_GearMotSteer3.dVelMeasFrqHz,
-			m_GearMotSteer3.dBeltRatio,
-			m_GearMotSteer3.dGearRatio,
-			m_GearMotSteer3.iSign,
-			m_GearMotSteer3.dVelMaxEncIncrS,
-			m_GearMotSteer3.dAccIncrS2,
-			m_GearMotSteer3.dDecIncrS2,
-			m_GearMotSteer3.iEncOffsetIncr,
-			m_GearMotSteer3.bIsSteer,
-			m_GearMotSteer3.dCurrentToTorque,
-			m_GearMotSteer3.dCurrMax,
-			m_GearMotSteer3.iHomingDigIn);
+			m_PlatformParams.drive_param_steer.at(2).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_steer.at(2).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_steer.at(2).dBeltRatio,
+			m_PlatformParams.drive_param_steer.at(2).dGearRatio,
+			m_PlatformParams.drive_param_steer.at(2).iSign,
+			m_PlatformParams.drive_param_steer.at(2).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_steer.at(2).dAccIncrS2,
+			m_PlatformParams.drive_param_steer.at(2).dDecIncrS2,
+			m_PlatformParams.drive_param_steer.at(2).iEncOffsetIncr,
+			m_PlatformParams.drive_param_steer.at(2).bIsSteer,
+			m_PlatformParams.drive_param_steer.at(2).dCurrentToTorque,
+			m_PlatformParams.drive_param_steer.at(2).dCurrMax,
+			m_PlatformParams.drive_param_steer.at(2).iHomingDigIn);
 	}
 
 	if(m_iNumDrives == 4)
 	{
 		DriveParamW4DriveMotor.setParam(
 			6,
-			m_GearMotDrive4.iEncIncrPerRevMot,
-			m_GearMotDrive4.dVelMeasFrqHz,
-			m_GearMotDrive4.dBeltRatio,
-			m_GearMotDrive4.dGearRatio,
-			m_GearMotDrive4.iSign,
-			m_GearMotDrive4.dVelMaxEncIncrS,
-			m_GearMotDrive4.dAccIncrS2,
-			m_GearMotDrive4.dDecIncrS2,
-			m_GearMotDrive4.iEncOffsetIncr,
-			m_GearMotDrive4.bIsSteer,
-			m_GearMotDrive4.dCurrentToTorque,
-			m_GearMotDrive4.dCurrMax,
-			m_GearMotDrive4.iHomingDigIn);
+			m_PlatformParams.drive_param_drive.at(3).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_drive.at(3).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_drive.at(3).dBeltRatio,
+			m_PlatformParams.drive_param_drive.at(3).dGearRatio,
+			m_PlatformParams.drive_param_drive.at(3).iSign,
+			m_PlatformParams.drive_param_drive.at(3).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_drive.at(3).dAccIncrS2,
+			m_PlatformParams.drive_param_drive.at(3).dDecIncrS2,
+			m_PlatformParams.drive_param_drive.at(3).iEncOffsetIncr,
+			m_PlatformParams.drive_param_drive.at(3).bIsSteer,
+			m_PlatformParams.drive_param_drive.at(3).dCurrentToTorque,
+			m_PlatformParams.drive_param_drive.at(3).dCurrMax,
+			m_PlatformParams.drive_param_drive.at(3).iHomingDigIn);
 	}
 	
 	if(m_iNumDrives == 4)
 	{
 		DriveParamW4SteerMotor.setParam(
 			7,
-			m_GearMotSteer4.iEncIncrPerRevMot,
-			m_GearMotSteer4.dVelMeasFrqHz,
-			m_GearMotSteer4.dBeltRatio,
-			m_GearMotSteer4.dGearRatio,
-			m_GearMotSteer4.iSign,
-			m_GearMotSteer4.dVelMaxEncIncrS,
-			m_GearMotSteer4.dAccIncrS2,
-			m_GearMotSteer4.dDecIncrS2,
-			m_GearMotSteer4.iEncOffsetIncr,
-			m_GearMotSteer4.bIsSteer,
-			m_GearMotSteer4.dCurrentToTorque,
-			m_GearMotSteer4.dCurrMax,
-			m_GearMotSteer4.iHomingDigIn);
+			m_PlatformParams.drive_param_steer.at(3).iEncIncrPerRevMot,
+			m_PlatformParams.drive_param_steer.at(3).dVelMeasFrqHz,
+			m_PlatformParams.drive_param_steer.at(3).dBeltRatio,
+			m_PlatformParams.drive_param_steer.at(3).dGearRatio,
+			m_PlatformParams.drive_param_steer.at(3).iSign,
+			m_PlatformParams.drive_param_steer.at(3).dVelMaxEncIncrS,
+			m_PlatformParams.drive_param_steer.at(3).dAccIncrS2,
+			m_PlatformParams.drive_param_steer.at(3).dDecIncrS2,
+			m_PlatformParams.drive_param_steer.at(3).iEncOffsetIncr,
+			m_PlatformParams.drive_param_steer.at(3).bIsSteer,
+			m_PlatformParams.drive_param_steer.at(3).dCurrentToTorque,
+			m_PlatformParams.drive_param_steer.at(3).dCurrMax,
+			m_PlatformParams.drive_param_steer.at(3).iHomingDigIn);
 	}
 	
-	m_IniFile.GetKeyDouble("US", "ScaleToMM", &dScaleToMM, true);
+	//m_IniFile.GetKeyDouble("US", "ScaleToMM", &dScaleToMM, true);
 
 
 	// read Platform.ini
 	m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
-
+*/
 
 	// ------ WHEEL 1 ------ //
 	// --- Motor Wheel 1 Drive
 	if(m_iNumDrives >= 1)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel1DriveMotor", &m_Param.iHasWheel1DriveMotor, true);
-		if (m_Param.iHasWheel1DriveMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel1DriveMotor", &m_Param.iHasWheel1DriveMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel1DriveMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel1DriveMotor available = 0" << std::endl;
@@ -726,8 +740,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel1DriveMotor available = type version 2" << std::endl;
 			m_vpMotor[0] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[0])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W1Drive, m_CanOpenIDParam.TxPDO2_W1Drive, m_CanOpenIDParam.RxPDO2_W1Drive,
-				m_CanOpenIDParam.TxSDO_W1Drive, m_CanOpenIDParam.RxSDO_W1Drive);
+				m_PlatformParams.canopen_ids.TxPDO1_W1Drive, m_PlatformParams.canopen_ids.TxPDO2_W1Drive, m_PlatformParams.canopen_ids.RxPDO2_W1Drive,
+				m_PlatformParams.canopen_ids.TxSDO_W1Drive, m_PlatformParams.canopen_ids.RxSDO_W1Drive);
 			m_vpMotor[0]->setCanItf(m_pCanCtrl);
 			m_vpMotor[0]->setDriveParam(DriveParamW1DriveMotor);
 		}
@@ -736,8 +750,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 1 Steer
 	if(m_iNumDrives >= 1)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel1SteerMotor", &m_Param.iHasWheel1SteerMotor, true);
-		if (m_Param.iHasWheel1SteerMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel1SteerMotor", &m_Param.iHasWheel1SteerMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel1SteerMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel1SteerMotor available = 0" << std::endl;
@@ -748,8 +762,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel1SteerMotor available = type version 2" << std::endl;
 			m_vpMotor[1] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[1])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W1Steer, m_CanOpenIDParam.TxPDO2_W1Steer, m_CanOpenIDParam.RxPDO2_W1Steer,
-				m_CanOpenIDParam.TxSDO_W1Steer, m_CanOpenIDParam.RxSDO_W1Steer);
+				m_PlatformParams.canopen_ids.TxPDO1_W1Steer, m_PlatformParams.canopen_ids.TxPDO2_W1Steer, m_PlatformParams.canopen_ids.RxPDO2_W1Steer,
+				m_PlatformParams.canopen_ids.TxSDO_W1Steer, m_PlatformParams.canopen_ids.RxSDO_W1Steer);
 			m_vpMotor[1]->setCanItf(m_pCanCtrl);
 			m_vpMotor[1]->setDriveParam(DriveParamW1SteerMotor);
 
@@ -760,8 +774,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 2 Drive
 	if(m_iNumDrives >= 2)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel2DriveMotor", &m_Param.iHasWheel2DriveMotor, true);
-		if (m_Param.iHasWheel2DriveMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel2DriveMotor", &m_Param.iHasWheel2DriveMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel2DriveMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel2DriveMotor available = 0" << std::endl;
@@ -772,8 +786,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel2DriveMotor available = type version 2" << std::endl;
 			m_vpMotor[2] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[2])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W2Drive, m_CanOpenIDParam.TxPDO2_W2Drive, m_CanOpenIDParam.RxPDO2_W2Drive,
-				m_CanOpenIDParam.TxSDO_W2Drive, m_CanOpenIDParam.RxSDO_W2Drive);
+				m_PlatformParams.canopen_ids.TxPDO1_W2Drive, m_PlatformParams.canopen_ids.TxPDO2_W2Drive, m_PlatformParams.canopen_ids.RxPDO2_W2Drive,
+				m_PlatformParams.canopen_ids.TxSDO_W2Drive, m_PlatformParams.canopen_ids.RxSDO_W2Drive);
 			m_vpMotor[2]->setCanItf(m_pCanCtrl);
 			m_vpMotor[2]->setDriveParam(DriveParamW2DriveMotor);
 		}
@@ -782,8 +796,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 2 Steer
 	if(m_iNumDrives >= 2)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel2SteerMotor", &m_Param.iHasWheel2SteerMotor, true);
-		if (m_Param.iHasWheel2SteerMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel2SteerMotor", &m_Param.iHasWheel2SteerMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel2SteerMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel2SteerMotor available = 0" << std::endl;
@@ -794,8 +808,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel2SteerMotor available = type version 2" << std::endl;
 			m_vpMotor[3] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[3])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W2Steer, m_CanOpenIDParam.TxPDO2_W2Steer, m_CanOpenIDParam.RxPDO2_W2Steer,
-				m_CanOpenIDParam.TxSDO_W2Steer, m_CanOpenIDParam.RxSDO_W2Steer);
+				m_PlatformParams.canopen_ids.TxPDO1_W2Steer, m_PlatformParams.canopen_ids.TxPDO2_W2Steer, m_PlatformParams.canopen_ids.RxPDO2_W2Steer,
+				m_PlatformParams.canopen_ids.TxSDO_W2Steer, m_PlatformParams.canopen_ids.RxSDO_W2Steer);
 			m_vpMotor[3]->setCanItf(m_pCanCtrl);
 			m_vpMotor[3]->setDriveParam(DriveParamW2SteerMotor);
 
@@ -806,8 +820,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 3 Drive
 	if(m_iNumDrives >= 3)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel3DriveMotor", &m_Param.iHasWheel3DriveMotor, true);
-		if (m_Param.iHasWheel3DriveMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel3DriveMotor", &m_Param.iHasWheel3DriveMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel3DriveMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel3DriveMotor available = 0" << std::endl;
@@ -818,8 +832,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel3DriveMotor available = type version 2" << std::endl;
 			m_vpMotor[4] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[4])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W3Drive, m_CanOpenIDParam.TxPDO2_W3Drive, m_CanOpenIDParam.RxPDO2_W3Drive,
-				m_CanOpenIDParam.TxSDO_W3Drive, m_CanOpenIDParam.RxSDO_W3Drive);
+				m_PlatformParams.canopen_ids.TxPDO1_W3Drive, m_PlatformParams.canopen_ids.TxPDO2_W3Drive, m_PlatformParams.canopen_ids.RxPDO2_W3Drive,
+				m_PlatformParams.canopen_ids.TxSDO_W3Drive, m_PlatformParams.canopen_ids.RxSDO_W3Drive);
 			m_vpMotor[4]->setCanItf(m_pCanCtrl);
 			m_vpMotor[4]->setDriveParam(DriveParamW3DriveMotor);
 		}
@@ -828,8 +842,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 3 Steer
 	if(m_iNumDrives >= 3)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel3SteerMotor", &m_Param.iHasWheel3SteerMotor, true);
-		if (m_Param.iHasWheel3SteerMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel3SteerMotor", &m_Param.iHasWheel3SteerMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel3SteerMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel3SteerMotor available = 0" << std::endl;
@@ -840,8 +854,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel3SteerMotor available = type version 2" << std::endl;
 			m_vpMotor[5] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[5])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W3Steer, m_CanOpenIDParam.TxPDO2_W3Steer, m_CanOpenIDParam.RxPDO2_W3Steer,
-				m_CanOpenIDParam.TxSDO_W3Steer, m_CanOpenIDParam.RxSDO_W3Steer);
+				m_PlatformParams.canopen_ids.TxPDO1_W3Steer, m_PlatformParams.canopen_ids.TxPDO2_W3Steer, m_PlatformParams.canopen_ids.RxPDO2_W3Steer,
+				m_PlatformParams.canopen_ids.TxSDO_W3Steer, m_PlatformParams.canopen_ids.RxSDO_W3Steer);
 			m_vpMotor[5]->setCanItf(m_pCanCtrl);
 			m_vpMotor[5]->setDriveParam(DriveParamW3SteerMotor);
 
@@ -852,8 +866,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 4 Drive
 	if(m_iNumDrives == 4)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel4DriveMotor", &m_Param.iHasWheel4DriveMotor, true);
-		if (m_Param.iHasWheel4DriveMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel4DriveMotor", &m_Param.iHasWheel4DriveMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel4DriveMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel4DriveMotor available = 0" << std::endl;
@@ -864,8 +878,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel4DriveMotor available = type version 2" << std::endl;
 			m_vpMotor[6] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[6])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W4Drive, m_CanOpenIDParam.TxPDO2_W4Drive, m_CanOpenIDParam.RxPDO2_W4Drive,
-				m_CanOpenIDParam.TxSDO_W4Drive, m_CanOpenIDParam.RxSDO_W4Drive);
+				m_PlatformParams.canopen_ids.TxPDO1_W4Drive, m_PlatformParams.canopen_ids.TxPDO2_W4Drive, m_PlatformParams.canopen_ids.RxPDO2_W4Drive,
+				m_PlatformParams.canopen_ids.TxSDO_W4Drive, m_PlatformParams.canopen_ids.RxSDO_W4Drive);
 			m_vpMotor[6]->setCanItf(m_pCanCtrl);
 			m_vpMotor[6]->setDriveParam(DriveParamW4DriveMotor);
 		}
@@ -874,8 +888,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 4 Steer
 	if(m_iNumDrives == 4)
 	{
-		m_IniFile.GetKeyInt("Config", "Wheel4SteerMotor", &m_Param.iHasWheel4SteerMotor, true);
-		if (m_Param.iHasWheel4SteerMotor == 0)
+		//m_IniFile.GetKeyInt("Config", "Wheel4SteerMotor", &m_Param.iHasWheel4SteerMotor, true);
+		if (m_PlatformParams.platform_config.iHasWheel4SteerMotor == 0)
 		{
 			// No motor
 			std::cout << "node Wheel4SteerMotor available = 0" << std::endl;
@@ -886,8 +900,8 @@ void CanCtrlPltfCOb3::readConfiguration()
 			std::cout << "Wheel4SteerMotor available = type version 2" << std::endl;
 			m_vpMotor[7] = new CanDriveHarmonica();
 			((CanDriveHarmonica*) m_vpMotor[7])->setCanOpenParam(
-				m_CanOpenIDParam.TxPDO1_W4Steer, m_CanOpenIDParam.TxPDO2_W4Steer, m_CanOpenIDParam.RxPDO2_W4Steer,
-				m_CanOpenIDParam.TxSDO_W4Steer, m_CanOpenIDParam.RxSDO_W4Steer);
+				m_PlatformParams.canopen_ids.TxPDO1_W4Steer, m_PlatformParams.canopen_ids.TxPDO2_W4Steer, m_PlatformParams.canopen_ids.RxPDO2_W4Steer,
+				m_PlatformParams.canopen_ids.TxSDO_W4Steer, m_PlatformParams.canopen_ids.RxSDO_W4Steer);
 			m_vpMotor[7]->setCanItf(m_pCanCtrl);
 			m_vpMotor[7]->setDriveParam(DriveParamW4SteerMotor);
 

--- a/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
+++ b/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
@@ -71,16 +71,6 @@ CanCtrlPltfCOb3::CanCtrlPltfCOb3(PlatformParams platform_parameters)
 	//sIniDirectory = iniDirectory;
 	m_PlatformParams = platform_parameters;
 
-
-	/*	
-	IniFile iniFile;
-	iniFile.SetFileName(sIniDirectory + "Platform.ini", "PltfHardwareCoB3.h");
-
-	// get max Joint-Velocities (in rad/s) for Steer- and Drive-Joint
-	iniFile.GetKeyInt("Config", "NumberOfMotors", &m_iNumMotors, true);
-	iniFile.GetKeyInt("Config", "NumberOfWheels", &m_iNumDrives, true);
-	*/
-	
 	m_iNumDrives = m_PlatformParams.num_wheels;
 	m_iNumMotors = m_iNumDrives * 2;
 
@@ -120,119 +110,7 @@ CanCtrlPltfCOb3::CanCtrlPltfCOb3(PlatformParams platform_parameters)
 	if(m_iNumMotors == 8)
 		m_viMotorID[7] = CANNODE_WHEEL4STEERMOTOR;
 
-	// ------------- parameters
-	// m_Param.dCanTimeout = m_PlatformParams.platform_config.dCanTimeout;
-
-	/*
-	if(m_iNumMotors >= 1)
-		m_Param.iHasWheel1DriveMotor = 0;
-	if(m_iNumMotors >= 2)
-		m_Param.iHasWheel1SteerMotor = 0;
-	if(m_iNumMotors >= 3)
-		m_Param.iHasWheel2DriveMotor = 0;
-	if(m_iNumMotors >= 4)
-		m_Param.iHasWheel2SteerMotor = 0;
-	if(m_iNumMotors >= 5)
-		m_Param.iHasWheel3DriveMotor = 0;
-	if(m_iNumMotors >= 6)
-		m_Param.iHasWheel3SteerMotor = 0;
-	if(m_iNumMotors >= 7)
-		m_Param.iHasWheel4DriveMotor = 0;
-	if(m_iNumMotors == 8)
-		m_Param.iHasWheel4SteerMotor = 0;
-	*/
-	
-	/*
-	m_Param.iHasRelayBoard = 0;
-	m_Param.iHasIOBoard = 0;
-	m_Param.iHasUSBoard = 0;
-	m_Param.iHasGyroBoard = 0;
-	m_Param.iHasRadarBoard = 0;	
-	*/
-
 	m_bWatchdogErr = false;
-	
-	/*
-	// ------------ Default CAN-IDs for CanOpen (Harmonica)
-	// Wheel 1
-	// can adresse motor 1
-	if(m_iNumMotors >= 1)
-	{
-		m_CanOpenIDParam.TxPDO1_W1Drive = 0x182;
-		m_CanOpenIDParam.TxPDO2_W1Drive = 0x282;
-		m_CanOpenIDParam.RxPDO2_W1Drive = 0x302;
-		m_CanOpenIDParam.TxSDO_W1Drive = 0x582;
-		m_CanOpenIDParam.RxSDO_W1Drive = 0x602;
-	}
-	// can adresse motor 2
-	if(m_iNumMotors >= 2)
-	{
-		m_CanOpenIDParam.TxPDO1_W1Steer = 0x181;
-		m_CanOpenIDParam.TxPDO2_W1Steer = 0x281;
-		m_CanOpenIDParam.RxPDO2_W1Steer = 0x301;
-		m_CanOpenIDParam.TxSDO_W1Steer = 0x581;
-		m_CanOpenIDParam.RxSDO_W1Steer = 0x601;
-	}
-	// Wheel 2
-	// can adresse motor 7
-	if(m_iNumMotors >= 3)
-	{
-		m_CanOpenIDParam.TxPDO1_W2Drive = 0x184;
-		m_CanOpenIDParam.TxPDO2_W2Drive = 0x284;
-		m_CanOpenIDParam.RxPDO2_W2Drive = 0x304;
-		m_CanOpenIDParam.TxSDO_W2Drive = 0x584;
-		m_CanOpenIDParam.RxSDO_W2Drive = 0x604;
-	}
-	// can adresse motor 8
-	if(m_iNumMotors >= 4)
-	{
-		m_CanOpenIDParam.TxPDO1_W2Steer = 0x183;
-		m_CanOpenIDParam.TxPDO2_W2Steer = 0x283;
-		m_CanOpenIDParam.RxPDO2_W2Steer = 0x303;
-		m_CanOpenIDParam.TxSDO_W2Steer = 0x583;
-		m_CanOpenIDParam.RxSDO_W2Steer = 0x603;
-	}
-	// Wheel 3
-	// can adresse motor 5
-	if(m_iNumMotors >= 5)
-	{
-		m_CanOpenIDParam.TxPDO1_W3Drive = 0x188;
-		m_CanOpenIDParam.TxPDO2_W3Drive = 0x288;
-		m_CanOpenIDParam.RxPDO2_W3Drive = 0x308;
-		m_CanOpenIDParam.TxSDO_W3Drive = 0x588;
-		m_CanOpenIDParam.RxSDO_W3Drive = 0x608;
-	}
-	// can adresse motor 6
-	if(m_iNumMotors >= 6)
-	{
-		m_CanOpenIDParam.TxPDO1_W3Steer = 0x187;
-		m_CanOpenIDParam.TxPDO2_W3Steer = 0x287;
-		m_CanOpenIDParam.RxPDO2_W3Steer = 0x307;
-		m_CanOpenIDParam.TxSDO_W3Steer = 0x587;
-		m_CanOpenIDParam.RxSDO_W3Steer = 0x607;
-	}
-	// Wheel 4
-	// can adresse motor 3
-	if(m_iNumMotors >= 7)
-	{
-		m_CanOpenIDParam.TxPDO1_W4Drive = 0x186;
-		m_CanOpenIDParam.TxPDO2_W4Drive = 0x286;
-		m_CanOpenIDParam.RxPDO2_W4Drive = 0x306;
-		m_CanOpenIDParam.TxSDO_W4Drive = 0x586;
-		m_CanOpenIDParam.RxSDO_W4Drive = 0x606;
-	}
-	// can adresse motor 4
-	if(m_iNumMotors == 8)
-	{
-		m_CanOpenIDParam.TxPDO1_W4Steer = 0x185;
-		m_CanOpenIDParam.TxPDO2_W4Steer = 0x285;
-		m_CanOpenIDParam.RxPDO2_W4Steer = 0x305;
-		m_CanOpenIDParam.TxSDO_W4Steer = 0x585;
-		m_CanOpenIDParam.RxSDO_W4Steer = 0x605;
-	}
-	*/
-	
-	std::cout << "  CHECK 1" << std::endl;
 }
 
 //-----------------------------------------------
@@ -257,10 +135,6 @@ CanCtrlPltfCOb3::~CanCtrlPltfCOb3()
 //-----------------------------------------------
 void CanCtrlPltfCOb3::readConfiguration()
 {
-
-	//int iTypeCan = 0;
-	//int iMaxMessages = 0;
-
 	DriveParam DriveParamW1DriveMotor;
 	DriveParam DriveParamW1SteerMotor;
 	DriveParam DriveParamW2DriveMotor;
@@ -272,304 +146,14 @@ void CanCtrlPltfCOb3::readConfiguration()
 	
 	std::string strTypeDrive;
 	std::string strTypeSteer;
-
-	//double dScaleToMM;
 	
+	// Select CAN-interface here
 	m_pCanCtrl = new CANPeakSysUSB(m_PlatformParams.can_device_params);
-	/*
-	// read CanCtrl.ini
-	m_IniFile.SetFileName(sIniDirectory + "CanCtrl.ini", "CanCtrlPltfCOb3.cpp");
-
-	std::cout << "Can configuration of the platform:" << std::endl;
-	
-	// read Configuration of the Can-Network (CanCtrl.ini)
-	m_IniFile.GetKeyInt("TypeCan", "Can", &iTypeCan, true);
-	if (iTypeCan == 0)
-	{
-		sComposed = sIniDirectory;
-		sComposed += "CanCtrl.ini";
-		m_pCanCtrl = new CanPeakSys(sComposed.c_str());
-		std::cout << "Uses CAN-Peak-Systems dongle" << std::endl;
-	}
-	else if (iTypeCan == 1)
-	{
-		sComposed = sIniDirectory;
-		sComposed += "CanCtrl.ini";
-		m_pCanCtrl = new CANPeakSysUSB(sComposed.c_str());
-		std::cout << "Uses CAN-Peak-USB" << std::endl;
-	}
-	else if (iTypeCan == 2)
-	{
-		sComposed = sIniDirectory;
-		sComposed += "CanCtrl.ini";
-		m_pCanCtrl = new CanESD(sComposed.c_str(), false);
-		std::cout << "Uses CAN-ESD-card" << std::endl;
-	}
-	*/
-
-	// read Platform.ini (Coupling of Drive/Steer for Homing)
-	// m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
-
-	// m_IniFile.GetKeyInt("Geom", "RadiusWheel", &m_Param.iRadiusWheelMM, true);
-	// m_IniFile.GetKeyInt("Geom", "DistSteerAxisToDriveWheelCenter", &m_Param.iDistSteerAxisToDriveWheelMM, true);
-
-	/*
-	if(m_iNumDrives >= 1)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel1SteerDriveCoupling", &m_PlatformParams.platform_config.dWheel1SteerDriveCoupling, true);
-	if(m_iNumDrives >= 2)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel2SteerDriveCoupling", &m_Param.dWheel2SteerDriveCoupling, true);
-	if(m_iNumDrives >= 3)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel3SteerDriveCoupling", &m_Param.dWheel3SteerDriveCoupling, true);
-	if(m_iNumDrives == 4)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel4SteerDriveCoupling", &m_Param.dWheel4SteerDriveCoupling, true);
-	*/
-
 	
 	// CanOpenId's
 	m_CanOpenIDParam = m_PlatformParams.canopen_ids;
-	
-	/*
-	// Wheel 1
-	// DriveMotor
-	if(m_iNumDrives >= 1)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W1Drive", &m_CanOpenIDParam.TxPDO1_W1Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W1Drive", &m_CanOpenIDParam.TxPDO2_W1Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W1Drive", &m_CanOpenIDParam.RxPDO2_W1Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W1Drive", &m_CanOpenIDParam.TxSDO_W1Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W1Drive", &m_CanOpenIDParam.RxSDO_W1Drive, true);
-	}
-	// SteerMotor
-	if(m_iNumDrives >= 1)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W1Steer", &m_CanOpenIDParam.TxPDO1_W1Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W1Steer", &m_CanOpenIDParam.TxPDO2_W1Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W1Steer", &m_CanOpenIDParam.RxPDO2_W1Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W1Steer", &m_CanOpenIDParam.TxSDO_W1Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W1Steer", &m_CanOpenIDParam.RxSDO_W1Steer, true);
-	}
-	
-	// Wheel 2
-	// DriveMotor
-	if(m_iNumDrives >= 2)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W2Drive", &m_CanOpenIDParam.TxPDO1_W2Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W2Drive", &m_CanOpenIDParam.TxPDO2_W2Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W2Drive", &m_CanOpenIDParam.RxPDO2_W2Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W2Drive", &m_CanOpenIDParam.TxSDO_W2Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W2Drive", &m_CanOpenIDParam.RxSDO_W2Drive, true);
-	}
-	// SteerMotor
-	if(m_iNumDrives >= 2)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W2Steer", &m_CanOpenIDParam.TxPDO1_W2Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W2Steer", &m_CanOpenIDParam.TxPDO2_W2Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W2Steer", &m_CanOpenIDParam.RxPDO2_W2Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W2Steer", &m_CanOpenIDParam.TxSDO_W2Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W2Steer", &m_CanOpenIDParam.RxSDO_W2Steer, true);
-	}
-	
-	// Wheel 3
-	// DriveMotor
-	if(m_iNumDrives >= 3)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W3Drive", &m_CanOpenIDParam.TxPDO1_W3Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W3Drive", &m_CanOpenIDParam.TxPDO2_W3Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W3Drive", &m_CanOpenIDParam.RxPDO2_W3Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W3Drive", &m_CanOpenIDParam.TxSDO_W3Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W3Drive", &m_CanOpenIDParam.RxSDO_W3Drive, true);
-	}
-	// SteerMotor
-	if(m_iNumDrives >= 3)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W3Steer", &m_CanOpenIDParam.TxPDO1_W3Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W3Steer", &m_CanOpenIDParam.TxPDO2_W3Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W3Steer", &m_CanOpenIDParam.RxPDO2_W3Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W3Steer", &m_CanOpenIDParam.TxSDO_W3Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W3Steer", &m_CanOpenIDParam.RxSDO_W3Steer, true);
-	}
-	
-	// Wheel 4
-	// DriveMotor
-	if(m_iNumDrives >= 4)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W4Drive", &m_CanOpenIDParam.TxPDO1_W4Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W4Drive", &m_CanOpenIDParam.TxPDO2_W4Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W4Drive", &m_CanOpenIDParam.RxPDO2_W4Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W4Drive", &m_CanOpenIDParam.TxSDO_W4Drive, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W4Drive", &m_CanOpenIDParam.RxSDO_W4Drive, true);
-	}
-	// SteerMotor
-	if(m_iNumDrives == 4)
-	{
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO1_W4Steer", &m_CanOpenIDParam.TxPDO1_W4Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxPDO2_W4Steer", &m_CanOpenIDParam.TxPDO2_W4Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxPDO2_W4Steer", &m_CanOpenIDParam.RxPDO2_W4Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "TxSDO_W4Steer", &m_CanOpenIDParam.TxSDO_W4Steer, true);
-		m_IniFile.GetKeyInt("CanOpenIDs", "RxSDO_W4Steer", &m_CanOpenIDParam.RxSDO_W4Steer, true);
-	}
-	*/
 
-	// read configuration of the Drives (CanCtrl.ini)
-	/* Drivemotor1-Parameters Old
-	m_IniFile.GetKeyString("TypeDrive", "Drive1", &strTypeDrive, true);	
-	m_IniFile.GetKeyInt(strTypeDrive.c_str(), "EncIncrPerRevMot", &(m_GearMotDrive1.iEncIncrPerRevMot), true);
-	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "VelMeasFrqHz", &(m_GearMotDrive1.dVelMeasFrqHz), true);
-	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "BeltRatio", &(m_GearMotDrive1.dBeltRatio), true);
-	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "GearRatio", &(m_GearMotDrive1.dGearRatio), true);
-	m_IniFile.GetKeyInt(strTypeDrive.c_str(), "Sign", &(m_GearMotDrive1.iSign), true);
-	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "VelMaxEncIncrS", &(m_GearMotDrive1.dVelMaxEncIncrS), true);
-	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "AccIncrS", &(m_GearMotDrive1.dAccIncrS2), true);
-	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "DecIncrS", &(m_GearMotDrive1.dDecIncrS2), true);
-	m_IniFile.GetKeyDouble(strTypeDrive.c_str(), "EncOffsetIncr",&(m_GearMotDrive1.iEncOffsetIncr),true);
-	*/
-
-	/*
-	// "Drive Motor Type1" drive parameters	
-	if(m_iNumDrives >= 1)
-	{
-		m_IniFile.GetKeyInt("Drive1", "EncIncrPerRevMot", &(m_GearMotDrive1.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Drive1", "VelMeasFrqHz", &(m_GearMotDrive1.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Drive1", "BeltRatio", &(m_GearMotDrive1.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Drive1", "GearRatio", &(m_GearMotDrive1.dGearRatio), true);
-		m_IniFile.GetKeyInt("Drive1", "Sign", &(m_GearMotDrive1.iSign), true);
-		m_IniFile.GetKeyDouble("Drive1", "VelMaxEncIncrS", &(m_GearMotDrive1.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Drive1", "AccIncrS", &(m_GearMotDrive1.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Drive1", "DecIncrS", &(m_GearMotDrive1.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Drive1", "EncOffsetIncr",&(m_GearMotDrive1.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Drive1", "IsSteering", &(m_GearMotDrive1.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Drive1", "CurrentToTorque", &(m_GearMotDrive1.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Drive1", "CurrMax", &(m_GearMotDrive1.dCurrMax), false);
-		m_IniFile.GetKeyInt("Drive1", "HomingDigIn", &(m_GearMotDrive1.iHomingDigIn), false);
-	}
-
-	// "Drive Motor Type2" drive parameters	
-	if(m_iNumDrives >= 2)
-	{
-		m_IniFile.GetKeyInt("Drive2", "EncIncrPerRevMot", &(m_GearMotDrive2.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Drive2", "VelMeasFrqHz", &(m_GearMotDrive2.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Drive2", "BeltRatio", &(m_GearMotDrive2.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Drive2", "GearRatio", &(m_GearMotDrive2.dGearRatio), true);
-		m_IniFile.GetKeyInt("Drive2", "Sign", &(m_GearMotDrive2.iSign), true);
-		m_IniFile.GetKeyDouble("Drive2", "VelMaxEncIncrS", &(m_GearMotDrive2.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Drive2", "AccIncrS", &(m_GearMotDrive2.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Drive2", "DecIncrS", &(m_GearMotDrive2.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Drive2", "EncOffsetIncr",&(m_GearMotDrive2.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Drive2", "IsSteering", &(m_GearMotDrive2.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Drive2", "CurrentToTorque", &(m_GearMotDrive2.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Drive2", "CurrMax", &(m_GearMotDrive2.dCurrMax), false);
-		m_IniFile.GetKeyInt("Drive2", "HomingDigIn", &(m_GearMotDrive2.iHomingDigIn), false);
-	}
-
-	// "Drive Motor Type3" drive parameters	
-	if(m_iNumDrives >= 3)
-	{
-		m_IniFile.GetKeyInt("Drive3", "EncIncrPerRevMot", &(m_GearMotDrive3.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Drive3", "VelMeasFrqHz", &(m_GearMotDrive3.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Drive3", "BeltRatio", &(m_GearMotDrive3.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Drive3", "GearRatio", &(m_GearMotDrive3.dGearRatio), true);
-		m_IniFile.GetKeyInt("Drive3", "Sign", &(m_GearMotDrive3.iSign), true);
-		m_IniFile.GetKeyDouble("Drive3", "VelMaxEncIncrS", &(m_GearMotDrive3.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Drive3", "AccIncrS", &(m_GearMotDrive3.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Drive3", "DecIncrS", &(m_GearMotDrive3.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Drive3", "EncOffsetIncr",&(m_GearMotDrive3.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Drive3", "IsSteering", &(m_GearMotDrive3.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Drive3", "CurrentToTorque", &(m_GearMotDrive3.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Drive3", "CurrMax", &(m_GearMotDrive3.dCurrMax), false);
-		m_IniFile.GetKeyInt("Drive3", "HomingDigIn", &(m_GearMotDrive3.iHomingDigIn), false);
-	}
-
-	// "Drive Motor Type4" drive parameters	
-	if(m_iNumDrives == 4)
-	{
-		m_IniFile.GetKeyInt("Drive4", "EncIncrPerRevMot", &(m_GearMotDrive4.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Drive4", "VelMeasFrqHz", &(m_GearMotDrive4.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Drive4", "BeltRatio", &(m_GearMotDrive4.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Drive4", "GearRatio", &(m_GearMotDrive4.dGearRatio), true);
-		m_IniFile.GetKeyInt("Drive4", "Sign", &(m_GearMotDrive4.iSign), true);
-		m_IniFile.GetKeyDouble("Drive4", "VelMaxEncIncrS", &(m_GearMotDrive4.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Drive4", "AccIncrS", &(m_GearMotDrive4.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Drive4", "DecIncrS", &(m_GearMotDrive4.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Drive4", "EncOffsetIncr",&(m_GearMotDrive4.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Drive4", "IsSteering", &(m_GearMotDrive4.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Drive4", "CurrentToTorque", &(m_GearMotDrive4.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Drive4", "CurrMax", &(m_GearMotDrive4.dCurrMax), false);
-		m_IniFile.GetKeyInt("Drive4", "HomingDigIn", &(m_GearMotDrive4.iHomingDigIn), false);
-	}
-
-	// "Steer Motor Type1" drive parameters	
-	if(m_iNumDrives >= 1)
-	{
-		m_IniFile.GetKeyInt("Steer1", "EncIncrPerRevMot", &(m_GearMotSteer1.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Steer1", "VelMeasFrqHz", &(m_GearMotSteer1.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Steer1", "BeltRatio", &(m_GearMotSteer1.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Steer1", "GearRatio", &(m_GearMotSteer1.dGearRatio), true);
-		m_IniFile.GetKeyInt("Steer1", "Sign", &(m_GearMotSteer1.iSign), true);
-		m_IniFile.GetKeyDouble("Steer1", "VelMaxEncIncrS", &(m_GearMotSteer1.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Steer1", "AccIncrS", &(m_GearMotSteer1.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Steer1", "DecIncrS", &(m_GearMotSteer1.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Steer1", "EncOffsetIncr",&(m_GearMotSteer1.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Steer1", "IsSteering", &(m_GearMotSteer1.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Steer1", "CurrentToTorque", &(m_GearMotSteer1.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Steer1", "CurrMax", &(m_GearMotSteer1.dCurrMax), false);
-		m_IniFile.GetKeyInt("Steer1", "HomingDigIn", &(m_GearMotSteer1.iHomingDigIn), false);
-	}
-
-	// "Steer Motor Type2" drive parameters	
-	if(m_iNumDrives >= 2)
-	{
-		m_IniFile.GetKeyInt("Steer2", "EncIncrPerRevMot", &(m_GearMotSteer2.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Steer2", "VelMeasFrqHz", &(m_GearMotSteer2.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Steer2", "BeltRatio", &(m_GearMotSteer2.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Steer2", "GearRatio", &(m_GearMotSteer2.dGearRatio), true);
-		m_IniFile.GetKeyInt("Steer2", "Sign", &(m_GearMotSteer2.iSign), true);
-		m_IniFile.GetKeyDouble("Steer2", "VelMaxEncIncrS", &(m_GearMotSteer2.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Steer2", "AccIncrS", &(m_GearMotSteer2.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Steer2", "DecIncrS", &(m_GearMotSteer2.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Steer2", "EncOffsetIncr",&(m_GearMotSteer2.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Steer2", "IsSteering", &(m_GearMotSteer2.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Steer2", "CurrentToTorque", &(m_GearMotSteer2.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Steer2", "CurrMax", &(m_GearMotSteer2.dCurrMax), false);
-		m_IniFile.GetKeyInt("Steer2", "HomingDigIn", &(m_GearMotSteer2.iHomingDigIn), false);
-	}
-
-	// "Steer Motor Type3" drive parameters	
-	if(m_iNumDrives >= 3)
-	{
-		m_IniFile.GetKeyInt("Steer3", "EncIncrPerRevMot", &(m_GearMotSteer3.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Steer3", "VelMeasFrqHz", &(m_GearMotSteer3.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Steer3", "BeltRatio", &(m_GearMotSteer3.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Steer3", "GearRatio", &(m_GearMotSteer3.dGearRatio), true);
-		m_IniFile.GetKeyInt("Steer3", "Sign", &(m_GearMotSteer3.iSign), true);
-		m_IniFile.GetKeyDouble("Steer3", "VelMaxEncIncrS", &(m_GearMotSteer3.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Steer3", "AccIncrS", &(m_GearMotSteer3.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Steer3", "DecIncrS", &(m_GearMotSteer3.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Steer3", "EncOffsetIncr",&(m_GearMotSteer3.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Steer3", "IsSteering", &(m_GearMotSteer3.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Steer3", "CurrentToTorque", &(m_GearMotSteer3.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Steer3", "CurrMax", &(m_GearMotSteer3.dCurrMax), false);
-		m_IniFile.GetKeyInt("Steer3", "HomingDigIn", &(m_GearMotSteer3.iHomingDigIn), false);
-	}
-
-	// "Steer Motor Type4" drive parameters	
-	if(m_iNumDrives == 4)
-	{
-		m_IniFile.GetKeyInt("Steer4", "EncIncrPerRevMot", &(m_GearMotSteer4.iEncIncrPerRevMot), true);
-		m_IniFile.GetKeyDouble("Steer4", "VelMeasFrqHz", &(m_GearMotSteer4.dVelMeasFrqHz), true);
-		m_IniFile.GetKeyDouble("Steer4", "BeltRatio", &(m_GearMotSteer4.dBeltRatio), true);
-		m_IniFile.GetKeyDouble("Steer4", "GearRatio", &(m_GearMotSteer4.dGearRatio), true);
-		m_IniFile.GetKeyInt("Steer4", "Sign", &(m_GearMotSteer4.iSign), true);
-		m_IniFile.GetKeyDouble("Steer4", "VelMaxEncIncrS", &(m_GearMotSteer4.dVelMaxEncIncrS), true);
-		m_IniFile.GetKeyDouble("Steer4", "AccIncrS", &(m_GearMotSteer4.dAccIncrS2), true);
-		m_IniFile.GetKeyDouble("Steer4", "DecIncrS", &(m_GearMotSteer4.dDecIncrS2), true);
-		m_IniFile.GetKeyInt("Steer4", "EncOffsetIncr",&(m_GearMotSteer4.iEncOffsetIncr),true);
-		m_IniFile.GetKeyBool("Steer4", "IsSteering", &(m_GearMotSteer4.bIsSteer), true);
-		m_IniFile.GetKeyDouble("Steer4", "CurrentToTorque", &(m_GearMotSteer4.dCurrentToTorque), false);
-		m_IniFile.GetKeyDouble("Steer4", "CurrMax", &(m_GearMotSteer4.dCurrMax), false);
-		m_IniFile.GetKeyInt("Steer4", "HomingDigIn", &(m_GearMotSteer4.iHomingDigIn), false);
-	}
-
-*/
+	// Drive parameters
 	if(m_iNumDrives >= 1)
 	{
 		DriveParamW1DriveMotor.setParam(
@@ -721,21 +305,11 @@ void CanCtrlPltfCOb3::readConfiguration()
 			m_PlatformParams.drive_param_steer.at(3).dCurrMax,
 			m_PlatformParams.drive_param_steer.at(3).iHomingDigIn);
 	}
-	
-	std::cout << "  CHECK 2" << std::endl;
-	
-	//m_IniFile.GetKeyDouble("US", "ScaleToMM", &dScaleToMM, true);
-
-
-	// read Platform.ini
-	// m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
-
 
 	// ------ WHEEL 1 ------ //
 	// --- Motor Wheel 1 Drive
 	if(m_iNumDrives >= 1)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel1DriveMotor", &m_Param.iHasWheel1DriveMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel1DriveMotor == 0)
 		{
 			// No motor
@@ -757,7 +331,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 1 Steer
 	if(m_iNumDrives >= 1)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel1SteerMotor", &m_Param.iHasWheel1SteerMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel1SteerMotor == 0)
 		{
 			// No motor
@@ -781,7 +354,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 2 Drive
 	if(m_iNumDrives >= 2)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel2DriveMotor", &m_Param.iHasWheel2DriveMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel2DriveMotor == 0)
 		{
 			// No motor
@@ -803,7 +375,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 2 Steer
 	if(m_iNumDrives >= 2)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel2SteerMotor", &m_Param.iHasWheel2SteerMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel2SteerMotor == 0)
 		{
 			// No motor
@@ -827,7 +398,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 3 Drive
 	if(m_iNumDrives >= 3)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel3DriveMotor", &m_Param.iHasWheel3DriveMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel3DriveMotor == 0)
 		{
 			// No motor
@@ -849,7 +419,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 3 Steer
 	if(m_iNumDrives >= 3)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel3SteerMotor", &m_Param.iHasWheel3SteerMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel3SteerMotor == 0)
 		{
 			// No motor
@@ -873,7 +442,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 4 Drive
 	if(m_iNumDrives == 4)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel4DriveMotor", &m_Param.iHasWheel4DriveMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel4DriveMotor == 0)
 		{
 			// No motor
@@ -895,7 +463,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 	// --- Motor Wheel 4 Steer
 	if(m_iNumDrives == 4)
 	{
-		//m_IniFile.GetKeyInt("Config", "Wheel4SteerMotor", &m_Param.iHasWheel4SteerMotor, true);
 		if (m_PlatformParams.platform_config.iHasWheel4SteerMotor == 0)
 		{
 			// No motor
@@ -914,10 +481,6 @@ void CanCtrlPltfCOb3::readConfiguration()
 
 		}
 	}
-
-	//m_IniFile.GetKeyInt("Config", "GenericBufferLen", &iMaxMessages, true);
-
-	std::cout << "  CHECK 3" << std::endl;
 }
 
 //-----------------------------------------------
@@ -954,7 +517,7 @@ int CanCtrlPltfCOb3::evalCanBuffer()
 //-----------------------------------------------
 bool CanCtrlPltfCOb3::initPltf()
 {	
-	// read Configuration parameters from Inifile
+	// read Configuration parameters
 	readConfiguration();
 		
 	// Vectors for drive objects and return values
@@ -964,8 +527,6 @@ bool CanCtrlPltfCOb3::initPltf()
 	std::vector<CanDriveItf*> vpSteerMotor;
 	bool bHomingOk;
 
-//	vbRetDriveMotor.assign(4,0);
-//	vbRetSteerMotor.assign(4,0);
 	vbRetDriveMotor.assign(m_iNumDrives,0);
 	vbRetSteerMotor.assign(m_iNumDrives,0);
 
@@ -973,17 +534,10 @@ bool CanCtrlPltfCOb3::initPltf()
 	// copy Motor-Pointer into Steer/Drive vector for more insight
 	for(int i=0; i<=m_iNumMotors; i+=2)
 		vpDriveMotor.push_back(m_vpMotor[i]);
-//	vpDriveMotor.push_back(m_vpMotor[2]);
-//	vpDriveMotor.push_back(m_vpMotor[4]);
-//	vpDriveMotor.push_back(m_vpMotor[6]);
 	for(int i=1; i<=m_iNumMotors; i+=2)
 		vpSteerMotor.push_back(m_vpMotor[i]);
-//	vpSteerMotor.push_back(m_vpMotor[3]);
-//	vpSteerMotor.push_back(m_vpMotor[5]);
-//	vpSteerMotor.push_back(m_vpMotor[7]);
 
 	std::vector<double> vdFactorVel;
-//	vdFactorVel.assign(4,0);
 	vdFactorVel.assign(m_iNumDrives,0);
 	double dhomeVeloRadS = -1.0;
 
@@ -1001,15 +555,6 @@ bool CanCtrlPltfCOb3::initPltf()
 	{
 		m_vpMotor[i]->startWatchdog(true);
 	}
-/*	m_vpMotor[0]->startWatchdog(true);
-	m_vpMotor[1]->startWatchdog(true);
-	m_vpMotor[2]->startWatchdog(true);
-	m_vpMotor[3]->startWatchdog(true);
-	m_vpMotor[4]->startWatchdog(true);
-	m_vpMotor[5]->startWatchdog(true);
-	m_vpMotor[6]->startWatchdog(true);
-	m_vpMotor[7]->startWatchdog(true);
-*/
 	usleep(10000);
 	
 	// 2nd send watchdogs to bed while initializing drives
@@ -1017,15 +562,6 @@ bool CanCtrlPltfCOb3::initPltf()
 	{
 		m_vpMotor[i]->startWatchdog(false);
 	}
-/*	m_vpMotor[0]->startWatchdog(false);
-	m_vpMotor[1]->startWatchdog(false);
-	m_vpMotor[2]->startWatchdog(false);
-	m_vpMotor[3]->startWatchdog(false);
-	m_vpMotor[4]->startWatchdog(false);
-	m_vpMotor[5]->startWatchdog(false);
-	m_vpMotor[6]->startWatchdog(false);
-	m_vpMotor[7]->startWatchdog(false);
-*/
 	usleep(100000);
 
 	std::cout << "Initialization of Watchdogs done" << std::endl;
@@ -1061,8 +597,6 @@ bool CanCtrlPltfCOb3::initPltf()
 		}	
 		
 		// perform homing only when ALL drives are ERROR-Free
-//		if (vbRetDriveMotor[0] && vbRetDriveMotor[1] && vbRetDriveMotor[2] && vbRetDriveMotor[3] &&
-//			vbRetSteerMotor[0] && vbRetSteerMotor[1] && vbRetSteerMotor[2] && vbRetSteerMotor[3])
 		bHomingOk = true;
 		for(int i=0; i<m_iNumDrives; i++)
 		{
@@ -1205,18 +739,7 @@ bool CanCtrlPltfCOb3::initPltf()
 	{
 		m_vpMotor[i]->startWatchdog(true);
 	}
-/*	m_vpMotor[0]->startWatchdog(true);
-	m_vpMotor[1]->startWatchdog(true);
-	m_vpMotor[2]->startWatchdog(true);
-	m_vpMotor[3]->startWatchdog(true);
-	m_vpMotor[4]->startWatchdog(true);
-	m_vpMotor[5]->startWatchdog(true);
-	m_vpMotor[6]->startWatchdog(true);
-	m_vpMotor[7]->startWatchdog(true);
-*/
-//	return  (
-//		vbRetDriveMotor[0] && vbRetDriveMotor[1] && vbRetDriveMotor[2] && vbRetDriveMotor[3] &&
-//		vbRetSteerMotor[0] && vbRetSteerMotor[1] && vbRetSteerMotor[2] && vbRetSteerMotor[3]);
+
 	bHomingOk = true;
 	for(int i=0; i<m_iNumDrives; i++)
 	{

--- a/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
+++ b/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
@@ -121,7 +121,7 @@ CanCtrlPltfCOb3::CanCtrlPltfCOb3(PlatformParams platform_parameters)
 		m_viMotorID[7] = CANNODE_WHEEL4STEERMOTOR;
 
 	// ------------- parameters
-	m_Param.dCanTimeout = m_PlatformParams.platform_config.dCanTimeout;
+	// m_Param.dCanTimeout = m_PlatformParams.platform_config.dCanTimeout;
 
 	/*
 	if(m_iNumMotors >= 1)
@@ -231,6 +231,8 @@ CanCtrlPltfCOb3::CanCtrlPltfCOb3(PlatformParams platform_parameters)
 		m_CanOpenIDParam.RxSDO_W4Steer = 0x605;
 	}
 	*/
+	
+	std::cout << "  CHECK 1" << std::endl;
 }
 
 //-----------------------------------------------
@@ -256,8 +258,8 @@ CanCtrlPltfCOb3::~CanCtrlPltfCOb3()
 void CanCtrlPltfCOb3::readConfiguration()
 {
 
-	int iTypeCan = 0;
-	int iMaxMessages = 0;
+	//int iTypeCan = 0;
+	//int iMaxMessages = 0;
 
 	DriveParam DriveParamW1DriveMotor;
 	DriveParam DriveParamW1SteerMotor;
@@ -306,19 +308,21 @@ void CanCtrlPltfCOb3::readConfiguration()
 	*/
 
 	// read Platform.ini (Coupling of Drive/Steer for Homing)
-	m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
+	// m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
 
-	m_IniFile.GetKeyInt("Geom", "RadiusWheel", &m_Param.iRadiusWheelMM, true);
-	m_IniFile.GetKeyInt("Geom", "DistSteerAxisToDriveWheelCenter", &m_Param.iDistSteerAxisToDriveWheelMM, true);
+	// m_IniFile.GetKeyInt("Geom", "RadiusWheel", &m_Param.iRadiusWheelMM, true);
+	// m_IniFile.GetKeyInt("Geom", "DistSteerAxisToDriveWheelCenter", &m_Param.iDistSteerAxisToDriveWheelMM, true);
 
+	/*
 	if(m_iNumDrives >= 1)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel1SteerDriveCoupling", &m_Param.dWheel1SteerDriveCoupling, true);
+		m_IniFile.GetKeyDouble("DrivePrms", "Wheel1SteerDriveCoupling", &m_PlatformParams.platform_config.dWheel1SteerDriveCoupling, true);
 	if(m_iNumDrives >= 2)
 		m_IniFile.GetKeyDouble("DrivePrms", "Wheel2SteerDriveCoupling", &m_Param.dWheel2SteerDriveCoupling, true);
 	if(m_iNumDrives >= 3)
 		m_IniFile.GetKeyDouble("DrivePrms", "Wheel3SteerDriveCoupling", &m_Param.dWheel3SteerDriveCoupling, true);
 	if(m_iNumDrives == 4)
 		m_IniFile.GetKeyDouble("DrivePrms", "Wheel4SteerDriveCoupling", &m_Param.dWheel4SteerDriveCoupling, true);
+	*/
 
 	
 	// CanOpenId's
@@ -565,6 +569,7 @@ void CanCtrlPltfCOb3::readConfiguration()
 		m_IniFile.GetKeyInt("Steer4", "HomingDigIn", &(m_GearMotSteer4.iHomingDigIn), false);
 	}
 
+*/
 	if(m_iNumDrives >= 1)
 	{
 		DriveParamW1DriveMotor.setParam(
@@ -717,12 +722,14 @@ void CanCtrlPltfCOb3::readConfiguration()
 			m_PlatformParams.drive_param_steer.at(3).iHomingDigIn);
 	}
 	
+	std::cout << "  CHECK 2" << std::endl;
+	
 	//m_IniFile.GetKeyDouble("US", "ScaleToMM", &dScaleToMM, true);
 
 
 	// read Platform.ini
-	m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
-*/
+	// m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
+
 
 	// ------ WHEEL 1 ------ //
 	// --- Motor Wheel 1 Drive
@@ -908,9 +915,9 @@ void CanCtrlPltfCOb3::readConfiguration()
 		}
 	}
 
-	m_IniFile.GetKeyInt("Config", "GenericBufferLen", &iMaxMessages, true);
+	//m_IniFile.GetKeyInt("Config", "GenericBufferLen", &iMaxMessages, true);
 
-
+	std::cout << "  CHECK 3" << std::endl;
 }
 
 //-----------------------------------------------
@@ -1066,13 +1073,13 @@ bool CanCtrlPltfCOb3::initPltf()
 		{
 			// Calc Compensation factor for Velocity:
 			if(m_iNumDrives >= 1)
-				vdFactorVel[0] = - m_Param.dWheel1SteerDriveCoupling + double(m_Param.iDistSteerAxisToDriveWheelMM) / double(m_Param.iRadiusWheelMM);
+				vdFactorVel[0] = - m_PlatformParams.steer_drive_coupling.at(0) + double(m_PlatformParams.platform_config.iDistSteerAxisToDriveWheelMM) / double(m_PlatformParams.platform_config.iRadiusWheelMM);
 			if(m_iNumDrives >= 2)
-				vdFactorVel[1] = - m_Param.dWheel2SteerDriveCoupling + double(m_Param.iDistSteerAxisToDriveWheelMM) / double(m_Param.iRadiusWheelMM);
+				vdFactorVel[1] = - m_PlatformParams.steer_drive_coupling.at(1) + double(m_PlatformParams.platform_config.iDistSteerAxisToDriveWheelMM) / double(m_PlatformParams.platform_config.iRadiusWheelMM);
 			if(m_iNumDrives >= 3)
-				vdFactorVel[2] = - m_Param.dWheel3SteerDriveCoupling + double(m_Param.iDistSteerAxisToDriveWheelMM) / double(m_Param.iRadiusWheelMM);
+				vdFactorVel[2] = - m_PlatformParams.steer_drive_coupling.at(2) + double(m_PlatformParams.platform_config.iDistSteerAxisToDriveWheelMM) / double(m_PlatformParams.platform_config.iRadiusWheelMM);
 			if(m_iNumDrives == 4)
-				vdFactorVel[3] = - m_Param.dWheel4SteerDriveCoupling + double(m_Param.iDistSteerAxisToDriveWheelMM) / double(m_Param.iRadiusWheelMM);
+				vdFactorVel[3] = - m_PlatformParams.steer_drive_coupling.at(3) + double(m_PlatformParams.platform_config.iDistSteerAxisToDriveWheelMM) / double(m_PlatformParams.platform_config.iRadiusWheelMM);
 
 			// initialize homing procedure
 			for (int i = 0; i<m_iNumDrives; i++)
@@ -1293,11 +1300,11 @@ bool CanCtrlPltfCOb3::isPltfError()
 	{
 		dWatchTime = m_vpMotor[i]->getTimeToLastMsg();
 
-		if(dWatchTime <  m_Param.dCanTimeout)
+		if(dWatchTime <  m_PlatformParams.platform_config.dCanTimeout)
 		{
 			m_bWatchdogErr = false;
 		}
-		if( (dWatchTime > m_Param.dCanTimeout) && (m_bWatchdogErr == false) )
+		if( (dWatchTime > m_PlatformParams.platform_config.dCanTimeout) && (m_bWatchdogErr == false) )
 		{
 			std::cout << "timeout CAN motor " << i << std::endl;
 			m_bWatchdogErr = true;

--- a/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
+++ b/cob_base_drive_chain/common/src/CanCtrlPltfCOb3.cpp
@@ -66,9 +66,11 @@
 
 //-----------------------------------------------
 
-CanCtrlPltfCOb3::CanCtrlPltfCOb3(std::string iniDirectory)
+CanCtrlPltfCOb3::CanCtrlPltfCOb3(std::string iniDirectory,PlatformParams platform_parameters)
 {	
 	sIniDirectory = iniDirectory;
+	m_PlatformParams = platform_parameters;
+	
 	IniFile iniFile;
 	iniFile.SetFileName(sIniDirectory + "Platform.ini", "PltfHardwareCoB3.h");
 
@@ -260,23 +262,10 @@ void CanCtrlPltfCOb3::readConfiguration()
 	std::string strTypeSteer;
 
 	double dScaleToMM;
-
-	// read Platform.ini (Coupling of Drive/Steer for Homing)
-	m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
-
-	m_IniFile.GetKeyInt("Geom", "RadiusWheel", &m_Param.iRadiusWheelMM, true);
-	m_IniFile.GetKeyInt("Geom", "DistSteerAxisToDriveWheelCenter", &m_Param.iDistSteerAxisToDriveWheelMM, true);
-
-	if(m_iNumDrives >= 1)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel1SteerDriveCoupling", &m_Param.dWheel1SteerDriveCoupling, true);
-	if(m_iNumDrives >= 2)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel2SteerDriveCoupling", &m_Param.dWheel2SteerDriveCoupling, true);
-	if(m_iNumDrives >= 3)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel3SteerDriveCoupling", &m_Param.dWheel3SteerDriveCoupling, true);
-	if(m_iNumDrives == 4)
-		m_IniFile.GetKeyDouble("DrivePrms", "Wheel4SteerDriveCoupling", &m_Param.dWheel4SteerDriveCoupling, true);
-
-
+	
+	m_pCanCtrl = new CANPeakSysUSB(m_PlatformParams.can_device_params);
+	
+	/*
 	// read CanCtrl.ini
 	m_IniFile.SetFileName(sIniDirectory + "CanCtrl.ini", "CanCtrlPltfCOb3.cpp");
 
@@ -305,6 +294,23 @@ void CanCtrlPltfCOb3::readConfiguration()
 		m_pCanCtrl = new CanESD(sComposed.c_str(), false);
 		std::cout << "Uses CAN-ESD-card" << std::endl;
 	}
+	*/
+
+	// read Platform.ini (Coupling of Drive/Steer for Homing)
+	m_IniFile.SetFileName(sIniDirectory + "Platform.ini", "CanCtrlPltfCOb3.cpp");
+
+	m_IniFile.GetKeyInt("Geom", "RadiusWheel", &m_Param.iRadiusWheelMM, true);
+	m_IniFile.GetKeyInt("Geom", "DistSteerAxisToDriveWheelCenter", &m_Param.iDistSteerAxisToDriveWheelMM, true);
+
+	if(m_iNumDrives >= 1)
+		m_IniFile.GetKeyDouble("DrivePrms", "Wheel1SteerDriveCoupling", &m_Param.dWheel1SteerDriveCoupling, true);
+	if(m_iNumDrives >= 2)
+		m_IniFile.GetKeyDouble("DrivePrms", "Wheel2SteerDriveCoupling", &m_Param.dWheel2SteerDriveCoupling, true);
+	if(m_iNumDrives >= 3)
+		m_IniFile.GetKeyDouble("DrivePrms", "Wheel3SteerDriveCoupling", &m_Param.dWheel3SteerDriveCoupling, true);
+	if(m_iNumDrives == 4)
+		m_IniFile.GetKeyDouble("DrivePrms", "Wheel4SteerDriveCoupling", &m_Param.dWheel4SteerDriveCoupling, true);
+
 
 	// CanOpenId's ----- Default values (DESIRE)
 	// Wheel 1

--- a/cob_base_drive_chain/ros/include/cob_base_drive_chain_param_loader.h
+++ b/cob_base_drive_chain/ros/include/cob_base_drive_chain_param_loader.h
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- * Copyright (c) 2010
+ * Copyright (c) 2012
  *
  * Fraunhofer Institute for Manufacturing Engineering	
  * and Automation (IPA)
@@ -8,17 +8,17 @@
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
  * Project name: care-o-bot
- * ROS stack name: cob_drivers
- * ROS package name: cob_generic_can
+ * ROS stack name: cob_intern
+ * ROS package name: cob_base_drive_chain
  * Description:
  *								
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *			
- * Author: Christian Connette, email:christian.connette@ipa.fhg.de
+ * Author: Philipp Koehler
  * Supervised by: Christian Connette, email:christian.connette@ipa.fhg.de
  *
- * Date of creation: Feb 2009
- * ToDo: Remove dependency to inifiles_old -> Inifile.h
+ * Date of creation: Jan 2012
+ * ToDo: 
  *
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
@@ -51,44 +51,26 @@
  *
  ****************************************************************/
 
-#ifndef CANPEAKSYSUSB_INCLUDEDEF_H
-#define CANPEAKSYSUSB_INCLUDEDEF_H
-//-----------------------------------------------
-#include <cob_generic_can/CanItf.h>
-#include <cob_generic_can/CanDeviceParams.h>
-#include <libpcan/libpcan.h>
+#ifndef BASE_DRIVE_CHAIN_PARAM_LOADER_INCLUDEDEF_H
+#define BASE_DRIVE_CHAIN_PARAM_LOADER_INCLUDEDEF_H
 
-//-----------------------------------------------
+#include <ros/ros.h>
 
-class CANPeakSysUSB : public CanItf
-{
+#include <cob_base_drive_chain/PlatformParams.h>
+
+
+class cob_base_drive_chain_param_loader {
 public:
-	// --------------- Interface
-	CANPeakSysUSB(CanDeviceParams can_device_params);
-	~CANPeakSysUSB();
-	void init();
-	void destroy() {};
-	bool transmitMsg(CanMsg CMsg, bool bBlocking = true);
-	bool receiveMsg(CanMsg* pCMsg);
-	bool receiveMsgRetry(CanMsg* pCMsg, int iNrOfRetry);
-	bool isObjectMode() { return false; }
+	cob_base_drive_chain_param_loader();
+	~cob_base_drive_chain_param_loader();
+	
+	bool read_configuration(ros::NodeHandle * n, std::string node_name);
+	
+	PlatformParams get_platform_params;
 
 private:
-	// --------------- Types
-	HANDLE m_handle;
-	
-	bool m_bInitialized;
-	std::string m_sDevicePath;
-	bool m_bSimuEnabled;
-	int m_iBaudrateVal;
-
-	static const int c_iInterrupt;
-	static const int c_iPort;
-	
-	bool initCAN();
-	
-	void outputDetailedStatus();
+	PlatformParams params;
 };
-//-----------------------------------------------
+
 #endif
 

--- a/cob_base_drive_chain/ros/include/cob_base_drive_chain_param_loader.h
+++ b/cob_base_drive_chain/ros/include/cob_base_drive_chain_param_loader.h
@@ -61,14 +61,17 @@
 
 class cob_base_drive_chain_param_loader {
 public:
-	cob_base_drive_chain_param_loader();
-	~cob_base_drive_chain_param_loader();
+	cob_base_drive_chain_param_loader(ros::NodeHandle * node_handle);
+	~cob_base_drive_chain_param_loader() {};
 	
-	bool read_configuration(ros::NodeHandle * n, std::string node_name);
+
 	
-	PlatformParams get_platform_params;
+	PlatformParams get_platform_params();
 
 private:
+	void read_configuration();
+	
+	ros::NodeHandle * n;
 	PlatformParams params;
 };
 

--- a/cob_base_drive_chain/ros/src/cob_base_drive_chain.cpp
+++ b/cob_base_drive_chain/ros/src/cob_base_drive_chain.cpp
@@ -208,7 +208,7 @@ class NodeClass
 		{
 			param_loader = new cob_base_drive_chain_param_loader(&n);
 			
-			param_loader->get_platform_params();
+			platform_parameters = param_loader->get_platform_params();
 			ROS_INFO("Successfully loaded platform parameters");
 			
 			m_iNumDrives = platform_parameters.num_wheels;
@@ -823,7 +823,7 @@ int main(int argc, char** argv)
 	NodeClass nodeClass;
 
 	// specify looprate of control-cycle
- 	ros::Rate loop_rate(1); // Hz 
+ 	ros::Rate loop_rate(100); // Hz 
 
 	while(nodeClass.n.ok())
 	{

--- a/cob_base_drive_chain/ros/src/cob_base_drive_chain.cpp
+++ b/cob_base_drive_chain/ros/src/cob_base_drive_chain.cpp
@@ -209,6 +209,8 @@ class NodeClass
 			param_loader = new cob_base_drive_chain_param_loader(&n);
 			
 			param_loader->get_platform_params();
+			ROS_INFO("Successfully loaded platform parameters");
+			
 			m_iNumDrives = platform_parameters.num_wheels;
 			m_iNumMotors = m_iNumDrives * 2;
 
@@ -821,7 +823,7 @@ int main(int argc, char** argv)
 	NodeClass nodeClass;
 
 	// specify looprate of control-cycle
- 	ros::Rate loop_rate(100); // Hz 
+ 	ros::Rate loop_rate(1); // Hz 
 
 	while(nodeClass.n.ok())
 	{

--- a/cob_base_drive_chain/ros/src/cob_base_drive_chain.cpp
+++ b/cob_base_drive_chain/ros/src/cob_base_drive_chain.cpp
@@ -77,6 +77,7 @@
 
 // external includes
 #include <cob_base_drive_chain/CanCtrlPltfCOb3.h>
+#include <cob_base_drive_chain/cob_base_drive_chain_param_loader.h>
 #include <cob_utilities/IniFile.h>
 #include <cob_utilities/MathSup.h>
 

--- a/cob_base_drive_chain/ros/src/cob_base_drive_chain_param_loader.cpp
+++ b/cob_base_drive_chain/ros/src/cob_base_drive_chain_param_loader.cpp
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- * Copyright (c) 2010
+ * Copyright (c) 2012
  *
  * Fraunhofer Institute for Manufacturing Engineering	
  * and Automation (IPA)
@@ -8,17 +8,17 @@
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
  * Project name: care-o-bot
- * ROS stack name: cob_drivers
- * ROS package name: cob_generic_can
+ * ROS stack name: cob_intern
+ * ROS package name: cob_base_drive_chain
  * Description:
  *								
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *			
- * Author: Christian Connette, email:christian.connette@ipa.fhg.de
+ * Author: Philipp Koehler
  * Supervised by: Christian Connette, email:christian.connette@ipa.fhg.de
  *
- * Date of creation: Feb 2009
- * ToDo: Remove dependency to inifiles_old -> Inifile.h
+ * Date of creation: Jan 2012
+ * ToDo: 
  *
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
@@ -51,44 +51,22 @@
  *
  ****************************************************************/
 
-#ifndef CANPEAKSYSUSB_INCLUDEDEF_H
-#define CANPEAKSYSUSB_INCLUDEDEF_H
-//-----------------------------------------------
-#include <cob_generic_can/CanItf.h>
-#include <cob_generic_can/CanDeviceParams.h>
-#include <libpcan/libpcan.h>
+#include <cob_base_drive_chain/cob_base_drive_chain_param_loader.h>
 
-//-----------------------------------------------
-
-class CANPeakSysUSB : public CanItf
-{
-public:
-	// --------------- Interface
-	CANPeakSysUSB(CanDeviceParams can_device_params);
-	~CANPeakSysUSB();
-	void init();
-	void destroy() {};
-	bool transmitMsg(CanMsg CMsg, bool bBlocking = true);
-	bool receiveMsg(CanMsg* pCMsg);
-	bool receiveMsgRetry(CanMsg* pCMsg, int iNrOfRetry);
-	bool isObjectMode() { return false; }
-
-private:
-	// --------------- Types
-	HANDLE m_handle;
+bool cob_base_drive_chain_param_loader::read_configuration(ros::NodeHandle * n, std::string node_name) {
+	//------------------------------------
+	//Reading parameters of CAN device
+	//------------------------------------
+	params.can_device_params.sDevicePath = "asdf";
+	params.can_device_params.iBaudrateVal = 0;
 	
-	bool m_bInitialized;
-	std::string m_sDevicePath;
-	bool m_bSimuEnabled;
-	int m_iBaudrateVal;
+	//------------------------------------
+	//Reading parameters for CAN device
+	//------------------------------------
+	
+	
+}
 
-	static const int c_iInterrupt;
-	static const int c_iPort;
-	
-	bool initCAN();
-	
-	void outputDetailedStatus();
-};
-//-----------------------------------------------
-#endif
+
+
 

--- a/cob_base_drive_chain/ros/src/cob_base_drive_chain_param_loader.cpp
+++ b/cob_base_drive_chain/ros/src/cob_base_drive_chain_param_loader.cpp
@@ -51,20 +51,220 @@
  *
  ****************************************************************/
 
-#include <cob_base_drive_chain/cob_base_drive_chain_param_loader.h>
+#include <ros/ros.h>
+#include <cob_base_drive_chain_param_loader.h>
 
-bool cob_base_drive_chain_param_loader::read_configuration(ros::NodeHandle * n, std::string node_name) {
+cob_base_drive_chain_param_loader::cob_base_drive_chain_param_loader(ros::NodeHandle * node_handle) {
+	n = node_handle;
+}
+
+PlatformParams cob_base_drive_chain_param_loader::get_platform_params() {
+	read_configuration();
+	
+	return params;
+};
+
+void cob_base_drive_chain_param_loader::read_configuration() {
 	//------------------------------------
 	//Reading parameters of CAN device
 	//------------------------------------
-	params.can_device_params.sDevicePath = "asdf";
-	params.can_device_params.iBaudrateVal = 0;
+	if(!n->hasParam("can_device_path")) ROS_WARN("Used default parameter for can_device_path");
+			n->param("can_device_path", params.can_device_params.sDevicePath, std::string("/dev/pcan2"));
+	
+	if(!n->hasParam("can_baudrate_val")) ROS_WARN("Used default parameter for can_baudrate_val");
+			n->param("can_baudrate_val", params.can_device_params.iBaudrateVal, 0);
 	
 	//------------------------------------
-	//Reading parameters for CAN device
+	//Reading general parameters
 	//------------------------------------
+	if(!n->hasParam("number_of_wheels")) ROS_WARN("Used default parameter for number_of_wheels");
+			n->param("number_of_wheels", params.num_wheels, 4);
 	
+	if(!n->hasParam("radius_wheels")) ROS_WARN("Used default parameter for radius_wheels");
+			n->param("radius_wheels", params.platform_config.iRadiusWheelMM, 75);
 	
+	if(!n->hasParam("dist_steer_axis_to_drive_wheel")) ROS_WARN("Used default parameter for dist_steer_axis_to_drive_wheel");
+			n->param("dist_steer_axis_to_drive_wheel", params.platform_config.iDistSteerAxisToDriveWheelMM, 22);
+			
+	if(!n->hasParam("can_comm_timeout")) ROS_WARN("Used default parameter for can_comm_timeout");
+			n->param("can_comm_timeout", params.platform_config.dCanTimeout, 7.0);
+			
+	if(!n->hasParam("max_drive_rate")) ROS_WARN("Used default parameter for max_drive_rate");
+			n->param("max_drive_rate", params.max_drive_rate_rad_s, 12.267);
+			
+	if(!n->hasParam("max_steer_rate")) ROS_WARN("Used default parameter for max_steer_rate");
+			n->param("max_steer_rate", params.max_steer_rate_rad_s, 24.4);
+			
+	// 0: no motor
+	// 1: motor of the type neo
+	// 2: motor of the type ham
+	params.platform_config.iHasWheel1DriveMotor = 0;
+	params.platform_config.iHasWheel1SteerMotor = 0;
+	params.platform_config.iHasWheel2DriveMotor = 0;
+	params.platform_config.iHasWheel2SteerMotor = 0;
+	params.platform_config.iHasWheel3DriveMotor = 0;
+	params.platform_config.iHasWheel3SteerMotor = 0;
+	params.platform_config.iHasWheel4DriveMotor = 0;
+	params.platform_config.iHasWheel4SteerMotor = 0;
+
+	if(params.num_wheels >= 1) {
+		params.platform_config.iHasWheel1DriveMotor = 2;
+		params.platform_config.iHasWheel1SteerMotor = 2;}
+	if(params.num_wheels >= 2) {
+		params.platform_config.iHasWheel2DriveMotor = 2;
+		params.platform_config.iHasWheel2SteerMotor = 2;}
+	if(params.num_wheels >= 3){
+		params.platform_config.iHasWheel3DriveMotor = 2;
+		params.platform_config.iHasWheel3SteerMotor = 2;}
+	if(params.num_wheels == 4){
+		params.platform_config.iHasWheel4DriveMotor = 2;
+		params.platform_config.iHasWheel4SteerMotor = 2;}
+
+	
+	//------------------------------------
+	//Reading parameters for each wheel
+	//------------------------------------
+	ros::NodeHandle * cur_joint_nh;
+	
+	params.drive_param_drive.assign(params.num_wheels, *(new GearMotorParamType));
+	params.drive_param_steer.assign(params.num_wheels, *(new GearMotorParamType));
+	params.steer_drive_coupling.assign(params.num_wheels, 0.0);
+	params.wheel_neutral_pos.assign(params.num_wheels, 0.0);
+	int can_id_temp;
+	
+	for(int i = 0; i<params.num_wheels; i++) {
+	
+	//Wheel#i, Drive
+		if(i==0) cur_joint_nh = new ros::NodeHandle(*n, "caster_front_left/drive");
+		else if (i==1) cur_joint_nh = new ros::NodeHandle(*n, "caster_back_left/drive");
+		else if (i==2) cur_joint_nh = new ros::NodeHandle(*n, "caster_back_right/drive");
+		else if (i==3) cur_joint_nh = new ros::NodeHandle(*n, "caster_front_right/drive");
+		
+		if(!cur_joint_nh->hasParam("SteerDriveCoupling")) ROS_WARN("Used default parameter for Wheel%d/drive SteerDriveCoupling", i+1);
+			cur_joint_nh->param("SteerDriveCoupling", params.steer_drive_coupling.at(i), 0.0);
+			
+		if(!cur_joint_nh->hasParam("WheelNeutralPosition")) ROS_WARN("Used default parameter for Wheel%d/drive WheelNeutralPosition", i+1);
+			cur_joint_nh->param("WheelNeutralPosition", params.wheel_neutral_pos.at(i), 0.0);
+		
+		if(!cur_joint_nh->hasParam("EncIncrPerRevMot")) ROS_WARN("Used default parameter for Wheel%d/drive EncIncrPerRevMot", i+1);
+			cur_joint_nh->param("EncIncrPerRevMot", params.drive_param_drive.at(i).iEncIncrPerRevMot, 4096);
+		if(!cur_joint_nh->hasParam("VelMeasFrqHz")) ROS_WARN("Used default parameter for Wheel%d/drive VelMeasFrqHz", i+1);
+			cur_joint_nh->param("VelMeasFrqHz", params.drive_param_drive.at(i).dVelMeasFrqHz, 1.0);
+		if(!cur_joint_nh->hasParam("BeltRatio")) ROS_WARN("Used default parameter for Wheel%d/drive BeltRatio", i+1);
+			cur_joint_nh->param("BeltRatio", params.drive_param_drive.at(i).dBeltRatio, 2.0);
+		if(!cur_joint_nh->hasParam("GearRatio")) ROS_WARN("Used default parameter for Wheel%d/drive GearRatio", i+1);
+			cur_joint_nh->param("GearRatio", params.drive_param_drive.at(i).dGearRatio, 15.0);
+		if(!cur_joint_nh->hasParam("Sign")) ROS_WARN("Used default parameter for Wheel%d/drive Sign", i+1);
+			cur_joint_nh->param("Sign", params.drive_param_drive.at(i).iSign, 1);
+		if(!cur_joint_nh->hasParam("VelMaxEncIncrS")) ROS_WARN("Used default parameter for Wheel%d/drive VelMaxEncIncrS", i+1);
+			cur_joint_nh->param("VelMaxEncIncrS", params.drive_param_drive.at(i).dVelMaxEncIncrS, 240000.0);
+		if(!cur_joint_nh->hasParam("AccIncrS")) ROS_WARN("Used default parameter for Wheel%d/drive AccIncrS", i+1);
+			cur_joint_nh->param("AccIncrS", params.drive_param_drive.at(i).dAccIncrS2, 500000.0);
+		if(!cur_joint_nh->hasParam("DecIncrS")) ROS_WARN("Used default parameter for Wheel%d/drive DecIncrS", i+1);
+			cur_joint_nh->param("DecIncrS", params.drive_param_drive.at(i).dDecIncrS2, 500000.0);
+		if(!cur_joint_nh->hasParam("EncOffsetIncr")) ROS_WARN("Used default parameter for Wheel%d/drive EncOffsetIncr", i+1);
+			cur_joint_nh->param("EncOffsetIncr", params.drive_param_drive.at(i).iEncOffsetIncr, 0);
+		if(!cur_joint_nh->hasParam("IsSteering")) ROS_WARN("Used default parameter for Wheel%d/drive IsSteering", i+1);
+			cur_joint_nh->param("IsSteering", params.drive_param_drive.at(i).bIsSteer, false);
+		if(!cur_joint_nh->hasParam("CurrentToTorque")) ROS_WARN("Used default parameter for Wheel%d/drive CurrentToTorque", i+1);
+			cur_joint_nh->param("CurrentToTorque", params.drive_param_drive.at(i).dCurrentToTorque, 0.10065);
+		if(!cur_joint_nh->hasParam("CurrMax")) ROS_WARN("Used default parameter for Wheel%d/drive CurrMax", i+1);
+			cur_joint_nh->param("CurrMax", params.drive_param_drive.at(i).dCurrMax, 9.62);
+		if(!cur_joint_nh->hasParam("HomingDigIn")) ROS_WARN("Used default parameter for Wheel%d/drive HomingDigIn", i+1);
+			cur_joint_nh->param("HomingDigIn", params.drive_param_drive.at(i).iHomingDigIn, 9);
+		//Read CAN-open-ids:
+		if(!cur_joint_nh->hasParam("CanOpenID")) ROS_FATAL("Used default parameter for Wheel%d/drive CanOpenID", i+1);
+			cur_joint_nh->param("CanOpenID", can_id_temp, 1);
+			if(i==0) {
+				params.canopen_ids.TxPDO1_W1Drive = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W1Drive = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W1Drive = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W1Drive = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W1Drive = 0x601 + can_id_temp -1;
+			} else if(i==1) {
+				params.canopen_ids.TxPDO1_W2Drive = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W2Drive = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W2Drive = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W2Drive = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W2Drive = 0x601 + can_id_temp -1;
+			} else if(i==2) {
+				params.canopen_ids.TxPDO1_W3Drive = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W3Drive = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W3Drive = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W3Drive = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W3Drive = 0x601 + can_id_temp -1;
+			} else if(i==3) {
+				params.canopen_ids.TxPDO1_W4Drive = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W4Drive = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W4Drive = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W4Drive = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W4Drive = 0x601 + can_id_temp -1;
+			}
+		
+	
+	//Wheel#i, Steer
+		if(i==0) cur_joint_nh = new ros::NodeHandle(*n, "caster_front_left/steer");
+		else if (i==1) cur_joint_nh = new ros::NodeHandle(*n, "caster_back_left/steer");
+		else if (i==2) cur_joint_nh = new ros::NodeHandle(*n, "caster_back_right/steer");
+		else if (i==3) cur_joint_nh = new ros::NodeHandle(*n, "caster_front_right/steer");
+		
+		if(!cur_joint_nh->hasParam("EncIncrPerRevMot")) ROS_WARN("Used default parameter for Wheel%d/steer EncIncrPerRevMot", i+1);
+			cur_joint_nh->param("EncIncrPerRevMot", params.drive_param_drive.at(i).iEncIncrPerRevMot, 4096);
+		if(!cur_joint_nh->hasParam("VelMeasFrqHz")) ROS_WARN("Used default parameter for Wheel%d/steer VelMeasFrqHz", i+1);
+			cur_joint_nh->param("VelMeasFrqHz", params.drive_param_drive.at(i).dVelMeasFrqHz, 1.0);
+		if(!cur_joint_nh->hasParam("BeltRatio")) ROS_WARN("Used default parameter for Wheel%d/steer BeltRatio", i+1);
+			cur_joint_nh->param("BeltRatio", params.drive_param_drive.at(i).dBeltRatio, 1.0);
+		if(!cur_joint_nh->hasParam("GearRatio")) ROS_WARN("Used default parameter for Wheel%d/steer GearRatio", i+1);
+			cur_joint_nh->param("GearRatio", params.drive_param_drive.at(i).dGearRatio, 12.66666666);
+		if(!cur_joint_nh->hasParam("Sign")) ROS_WARN("Used default parameter for Wheel%d/steer Sign", i+1);
+			cur_joint_nh->param("Sign", params.drive_param_drive.at(i).iSign, 1);
+		if(!cur_joint_nh->hasParam("VelMaxEncIncrS")) ROS_WARN("Used default parameter for Wheel%d/steer VelMaxEncIncrS", i+1);
+			cur_joint_nh->param("VelMaxEncIncrS", params.drive_param_drive.at(i).dVelMaxEncIncrS, 240000.0);
+		if(!cur_joint_nh->hasParam("AccIncrS")) ROS_WARN("Used default parameter for Wheel%d/steer AccIncrS", i+1);
+			cur_joint_nh->param("AccIncrS", params.drive_param_drive.at(i).dAccIncrS2, 1000000.0);
+		if(!cur_joint_nh->hasParam("DecIncrS")) ROS_WARN("Used default parameter for Wheel%d/steer DecIncrS", i+1);
+			cur_joint_nh->param("DecIncrS", params.drive_param_drive.at(i).dDecIncrS2, 1000000.0);
+		if(!cur_joint_nh->hasParam("EncOffsetIncr")) ROS_WARN("Used default parameter for Wheel%d/steer EncOffsetIncr", i+1);
+			cur_joint_nh->param("EncOffsetIncr", params.drive_param_drive.at(i).iEncOffsetIncr, 0);
+		if(!cur_joint_nh->hasParam("IsSteering")) ROS_WARN("Used default parameter for Wheel%d/steer IsSteering", i+1);
+			cur_joint_nh->param("IsSteering", params.drive_param_drive.at(i).bIsSteer, true);
+		if(!cur_joint_nh->hasParam("CurrentToTorque")) ROS_WARN("Used default parameter for Wheel%d/steer CurrentToTorque", i+1);
+			cur_joint_nh->param("CurrentToTorque", params.drive_param_drive.at(i).dCurrentToTorque, 0.10065);
+		if(!cur_joint_nh->hasParam("CurrMax")) ROS_WARN("Used default parameter for Wheel%d/steer CurrMax", i+1);
+			cur_joint_nh->param("CurrMax", params.drive_param_drive.at(i).dCurrMax, 9.62);
+		if(!cur_joint_nh->hasParam("HomingDigIn")) ROS_WARN("Used default parameter for Wheel%d/steer HomingDigIn", i+1);
+			cur_joint_nh->param("HomingDigIn", params.drive_param_drive.at(i).iHomingDigIn, 9);
+		//Read CAN-open-ids:
+		if(!cur_joint_nh->hasParam("CanOpenID")) ROS_FATAL("Used default parameter for Wheel%d/steer CanOpenID", i+1);
+			cur_joint_nh->param("CanOpenID", can_id_temp, 1);
+			if(i==0) {
+				params.canopen_ids.TxPDO1_W1Steer = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W1Steer = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W1Steer = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W1Steer = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W1Steer = 0x601 + can_id_temp -1;
+			} else if(i==1) {
+				params.canopen_ids.TxPDO1_W2Steer = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W2Steer = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W2Steer = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W2Steer = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W2Steer = 0x601 + can_id_temp -1;
+			} else if(i==2) {
+				params.canopen_ids.TxPDO1_W3Steer = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W3Steer = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W3Steer = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W3Steer = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W3Steer = 0x601 + can_id_temp -1;
+			} else if(i==3) {
+				params.canopen_ids.TxPDO1_W4Steer = 0x181 + can_id_temp -1;
+				params.canopen_ids.TxPDO2_W4Steer = 0x281 + can_id_temp -1;
+				params.canopen_ids.RxPDO2_W4Steer = 0x301 + can_id_temp -1;
+				params.canopen_ids.TxSDO_W4Steer = 0x581 + can_id_temp -1;
+				params.canopen_ids.RxSDO_W4Steer = 0x601 + can_id_temp -1;
+			}
+	}
+	
+	return;
 }
 
 

--- a/cob_generic_can/common/include/cob_generic_can/CanDeviceParams.h
+++ b/cob_generic_can/common/include/cob_generic_can/CanDeviceParams.h
@@ -14,11 +14,11 @@
  *								
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *			
- * Author: Christian Connette, email:christian.connette@ipa.fhg.de
+ * Author: Philipp Köhler
  * Supervised by: Christian Connette, email:christian.connette@ipa.fhg.de
  *
- * Date of creation: Feb 2009
- * ToDo: Remove dependency to inifiles_old -> Inifile.h
+ * Date of creation: Jan 2012
+ * ToDo:
  *
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
@@ -51,44 +51,28 @@
  *
  ****************************************************************/
 
-#ifndef CANPEAKSYSUSB_INCLUDEDEF_H
-#define CANPEAKSYSUSB_INCLUDEDEF_H
+#ifndef CANDEVICEPARAMS_INCLUDEDEF_H
+#define CANDEVICEPARAMS_INCLUDEDEF_H
 //-----------------------------------------------
-#include <cob_generic_can/CanItf.h>
-#include <cob_generic_can/CanDeviceParams.h>
-#include <libpcan/libpcan.h>
+#include <cstring>
+#include <string>
 
 //-----------------------------------------------
-
-class CANPeakSysUSB : public CanItf
-{
+class CanDeviceParams {
 public:
-	// --------------- Interface
-	CANPeakSysUSB(CanDeviceParams can_device_params);
-	~CANPeakSysUSB();
-	void init();
-	void destroy() {};
-	bool transmitMsg(CanMsg CMsg, bool bBlocking = true);
-	bool receiveMsg(CanMsg* pCMsg);
-	bool receiveMsgRetry(CanMsg* pCMsg, int iNrOfRetry);
-	bool isObjectMode() { return false; }
-
-private:
-	// --------------- Types
-	HANDLE m_handle;
+	CanDeviceParams() {
+		sDevicePath = "";
+		iBaudrateVal = 0;
+	};
+	CanDeviceParams(std::string DevicePath, int BaudrateVal) {
+		sDevicePath = DevicePath;
+		iBaudrateVal = BaudrateVal;
+	}
 	
-	bool m_bInitialized;
-	std::string m_sDevicePath;
-	bool m_bSimuEnabled;
-	int m_iBaudrateVal;
-
-	static const int c_iInterrupt;
-	static const int c_iPort;
-	
-	bool initCAN();
-	
-	void outputDetailedStatus();
+	std::string sDevicePath;
+	int iBaudrateVal;
 };
+
 //-----------------------------------------------
 #endif
 

--- a/cob_generic_can/common/include/cob_generic_can/CanPeakSysUSB.h
+++ b/cob_generic_can/common/include/cob_generic_can/CanPeakSysUSB.h
@@ -56,14 +56,16 @@
 //-----------------------------------------------
 #include <cob_generic_can/CanItf.h>
 #include <libpcan/libpcan.h>
-#include <cob_utilities/IniFile.h>
+
+#include <cstring>
+#include <string>
 //-----------------------------------------------
 
 class CANPeakSysUSB : public CanItf
 {
 public:
 	// --------------- Interface
-	CANPeakSysUSB(const char* cIniFile);
+	CANPeakSysUSB(std::string sDevicePath, int iBaudrateVal);
 	~CANPeakSysUSB();
 	void init();
 	void destroy() {};
@@ -77,7 +79,7 @@ private:
 	HANDLE m_handle;
 	
 	bool m_bInitialized;
-	IniFile m_IniFile;
+	std::string m_sDevicePath;
 	bool m_bSimuEnabled;
 	int m_iBaudrateVal;
 

--- a/cob_generic_can/common/src/CanPeakSysUSB.cpp
+++ b/cob_generic_can/common/src/CanPeakSysUSB.cpp
@@ -52,8 +52,8 @@
  ****************************************************************/
 
 //#define __DEBUG__
-
 #include <cob_generic_can/CanPeakSysUSB.h>
+
 #include <stdlib.h>
 #include <cerrno>
 #include <sys/types.h>
@@ -61,13 +61,13 @@
 #include <fcntl.h>
 //-----------------------------------------------
 
-CANPeakSysUSB::CANPeakSysUSB(std::string sDevicePath, int iBaudrateVal)
+CANPeakSysUSB::CANPeakSysUSB(CanDeviceParams can_device_params)
 {
 	m_bInitialized = false;
 	
-	m_sDevicePath = sDevicePath;
+	m_sDevicePath = can_device_params.sDevicePath;
 	if(m_sDevicePath == "") m_sDevicePath = "/dev/pcan32";
-	m_iBaudrateVal = iBaudrateVal;
+	m_iBaudrateVal = can_device_params.iBaudrateVal;
 
 	init();
 }

--- a/cob_generic_can/common/src/CanPeakSysUSB.cpp
+++ b/cob_generic_can/common/src/CanPeakSysUSB.cpp
@@ -56,19 +56,18 @@
 #include <cob_generic_can/CanPeakSysUSB.h>
 #include <stdlib.h>
 #include <cerrno>
-#include <cstring>
-#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 //-----------------------------------------------
 
-CANPeakSysUSB::CANPeakSysUSB(const char* cIniFile)
+CANPeakSysUSB::CANPeakSysUSB(std::string sDevicePath, int iBaudrateVal)
 {
 	m_bInitialized = false;
-
-	// read IniFile
-	m_IniFile.SetFileName(cIniFile, "CanPeakSysUSB.cpp");
+	
+	m_sDevicePath = sDevicePath;
+	if(m_sDevicePath == "") m_sDevicePath = "/dev/pcan32";
+	m_iBaudrateVal = iBaudrateVal;
 
 	init();
 }
@@ -82,6 +81,25 @@ CANPeakSysUSB::~CANPeakSysUSB()
 	}
 }
 
+//-----------------------------------------------
+void CANPeakSysUSB::init() {
+	std::cout << "Trying to open CAN-device on " << m_sDevicePath << std::endl;
+
+	//m_handle = LINUX_CAN_Open("/dev/pcan32", O_RDWR | O_NONBLOCK);
+	m_handle = LINUX_CAN_Open(m_sDevicePath.c_str(), O_RDWR);
+
+	if (! m_handle)
+	{
+		// Fatal error
+		std::cout << "Cannot open CAN on USB: " << strerror(errno) << std::endl;
+		sleep(3);
+		exit(0);
+	}
+
+	initCAN();
+}
+
+/*
 //-----------------------------------------------
 void CANPeakSysUSB::init()
 {
@@ -107,6 +125,7 @@ void CANPeakSysUSB::init()
 	
 	initCAN();
 }
+*/
 
 //-------------------------------------------
 bool CANPeakSysUSB::transmitMsg(CanMsg CMsg, bool bBlocking)


### PR DESCRIPTION
Parametrierung von Fahrdrehmodulen / ElmoDrives über yaml-Files möglich, keine ini-Files mehr notwendig. 
TODOs:
- Test
- ini-Files "abtippen" in neue yaml Struktur (Undercarriage und Kopfachse)
- Kopfachse-Parametrierung von ini zu yaml umstellen
