### PR TITLE
Improvements to phidget driver

### DIFF
--- a/cob_phidgets/ros/config/phidget_config.yaml
+++ b/cob_phidgets/ros/config/phidget_config.yaml
@@ -3,7 +3,7 @@ update_mode: polling                #switch between poll and event driven proces
 
 boards:                             
   ifk_general:                      #phidget board with a name
-    serial_num: 272740              #phidget boards serial number
+    serial_num: 272849              #phidget boards serial number
     ratiometric: true
     sensors:                        #configured sensors of this board
        gripper_left_command:              #a sensor and name (URI) with which the Information will be published

--- a/cob_phidgets/ros/config/phidget_config.yaml
+++ b/cob_phidgets/ros/config/phidget_config.yaml
@@ -6,27 +6,36 @@ boards:
     serial_num: 272740              #phidget boards serial number
     ratiometric: true
     sensors:                        #configured sensors of this board
-       gripper_command:              #a sensor and name (URI) with which the Information will be published
+       gripper_left_command:              #a sensor and name (URI) with which the Information will be published
         type: digital_out           #type of the sensor [digital_out, digital_in, analog]
-        index: 2                    #port on which the information is physically connected to the phidget board
-       gripper_hall_fingers:
-        type: analog
-        index: 2
-       gripper_hall_x:
-        type: analog
-        index: 3
-       gripper_hall_y:
+        index: 0                    #port on which the information is physically connected to the phidget board
+       gripper_left_hall_fingers:
         type: analog
         index: 4
-       gripper_hall_z:
+       gripper_left_hall_x:
         type: analog
         index: 5
-       em_stop_scanner: 
-        type: digital_in
+       gripper_left_hall_y:
+        type: analog
+        index: 6
+       gripper_left_hall_z:
+        type: analog
+        index: 7
+       gripper_right_command:              #a sensor and name (URI) with which the Information will be published
+        type: digital_out           #type of the sensor [digital_out, digital_in, analog]
+        index: 1                    #port on which the information is physically connected to the phidget board
+       gripper_right_hall_fingers:
+        type: analog
         index: 0
-       em_stop_laser: 
-        type: digital_in
+       gripper_right_hall_x:
+        type: analog
         index: 1
+       gripper_right_hall_y:
+        type: analog
+        index: 2
+       gripper_right_hall_z:
+        type: analog
+        index: 3
  
   ifk_test: 
     serial_num: 272745

--- a/cob_phidgets/ros/include/cob_phidgets/phidget_manager.h
+++ b/cob_phidgets/ros/include/cob_phidgets/phidget_manager.h
@@ -60,9 +60,9 @@
 #ifndef _PHIDGETMANAGER_H_
 #define _PHIDGETMANAGER_H_
 
-#include <libphidgets/phidget21.h>
 #include <vector>
 #include <string>
+#include <cob_phidgets/phidget.h>
 
 struct AttachedDevice
 {

--- a/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
+++ b/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
@@ -65,6 +65,8 @@
 #include <cob_phidgets/SetDataRate.h>
 #include <cob_phidgets/SetDigitalSensor.h>
 #include <cob_phidgets/SetTriggerValue.h>
+#include <cob_phidgets/DigitalSensor.h>
+#include <cob_phidgets/AnalogSensor.h>
 
 #include <thread>
 #include <mutex>
@@ -80,6 +82,7 @@ private:
 	ros::NodeHandle _nh;
 	ros::Publisher _pubAnalog;
 	ros::Publisher _pubDigital;
+	ros::Subscriber _subDigital;
 	ros::ServiceServer _srvDigitalOut;
 	ros::ServiceServer _srvDataRate;
 	ros::ServiceServer _srvTriggerValue;
@@ -103,6 +106,7 @@ private:
 	std::map<int, std::string> _indexNameMapDigitalOut;
 	std::map<std::string, int> _indexNameMapDigitalOutRev;
 	std::map<int, std::string>::iterator _indexNameMapItr;
+	std::map<std::string, int>::iterator _indexNameMapRevItr;
 
 	auto readParams(XmlRpc::XmlRpcValue* sensor_params) -> void;
 
@@ -115,6 +119,7 @@ private:
 	auto outputChangeHandler(int index, int outputState) -> int;
 	auto sensorChangeHandler(int index, int sensorValue) -> int;
 
+	auto onDigitalOutCallback(const cob_phidgets::DigitalSensorConstPtr& msg) -> void;
 	auto setDigitalOutCallback(cob_phidgets::SetDigitalSensor::Request &req,
 										cob_phidgets::SetDigitalSensor::Response &res) -> bool;
 	auto setDataRateCallback(cob_phidgets::SetDataRate::Request &req,

--- a/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
+++ b/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
@@ -97,8 +97,11 @@ private:
 	std::mutex _mutex;
 
 	std::map<int, std::string> _indexNameMapAnalog;
+	std::map<std::string, int> _indexNameMapAnalogRev;
 	std::map<int, std::string> _indexNameMapDigitalIn;
+	std::map<std::string, int> _indexNameMapDigitalInRev;
 	std::map<int, std::string> _indexNameMapDigitalOut;
+	std::map<std::string, int> _indexNameMapDigitalOutRev;
 	std::map<int, std::string>::iterator _indexNameMapItr;
 
 	auto readParams(XmlRpc::XmlRpcValue* sensor_params) -> void;

--- a/cob_phidgets/ros/src/phidget_manager.cpp
+++ b/cob_phidgets/ros/src/phidget_manager.cpp
@@ -84,7 +84,7 @@ auto PhidgetManager::getAttachedDevices()-> std::vector<AttachedDevice>
 {
 	CPhidgetHandle* phidgetList;
 	int count;
-
+	ROS_INFO("getting attached Devices");
 	CPhidgetManager_getAttachedDevices((CPhidgetManagerHandle) _manHandle, &phidgetList, &count);
  
  	std::vector<AttachedDevice> attachedDevices;

--- a/cob_phidgets/ros/src/phidgetik_ros.cpp
+++ b/cob_phidgets/ros/src/phidgetik_ros.cpp
@@ -58,8 +58,6 @@
  ****************************************************************/
 
 #include <cob_phidgets/phidgetik_ros.h>
-#include <cob_phidgets/DigitalSensor.h>
-#include <cob_phidgets/AnalogSensor.h>
 
 PhidgetIKROS::PhidgetIKROS(ros::NodeHandle nh, int serial_num, std::string board_name, XmlRpc::XmlRpcValue* sensor_params, SensingMode mode)
 	:PhidgetIK(mode), _nh(nh), _serial_num(serial_num)
@@ -70,8 +68,9 @@ PhidgetIKROS::PhidgetIKROS(ros::NodeHandle nh, int serial_num, std::string board
 	_outputChanged.index=-1;
 	_outputChanged.state=0;
 
-	_pubAnalog = _nh.advertise<cob_phidgets::AnalogSensor>("analog_sensor", 1);
-	_pubDigital = _nh.advertise<cob_phidgets::DigitalSensor>("digital_sensor", 1);
+	_pubAnalog = _nh.advertise<cob_phidgets::AnalogSensor>("analog_sensors", 1);
+	_pubDigital = _nh.advertise<cob_phidgets::DigitalSensor>("digital_sensors", 1);
+	_subDigital = _nh.subscribe("set_digital_sensor", 1, &PhidgetIKROS::onDigitalOutCallback, this);
 
 	_srvDigitalOut = nodeHandle.advertiseService("set_digital", &PhidgetIKROS::setDigitalOutCallback, this);
 	_srvDataRate = nodeHandle.advertiseService("set_data_rate", &PhidgetIKROS::setDataRateCallback, this);
@@ -333,33 +332,67 @@ auto PhidgetIKROS::setDigitalOutCallback(cob_phidgets::SetDigitalSensor::Request
 	_outputChanged.state=0;
 	_mutex.unlock();
 
-	ROS_INFO("Setting digital output %i to state %i", _indexNameMapDigitalOutRev[req.uri], req.state);
-	this->setOutputState(_indexNameMapDigitalOutRev[req.uri], req.state);
-	//this->setOutputState(req.index, req.state);
-
-	ros::Time start = ros::Time::now();
-	while((ros::Time::now().toSec() - start.toSec()) < 1.0)
+	// this check is nessesary because [] operator on Maps inserts an element if it is not found
+	_indexNameMapRevItr = _indexNameMapDigitalOutRev.find(req.uri);
+	if(_indexNameMapRevItr != _indexNameMapDigitalOutRev.end())
 	{
-		_mutex.lock();
-		if(_outputChanged.updated == true)
+		ROS_INFO("Setting digital output %i to state %i", _indexNameMapDigitalOutRev[req.uri], req.state);
+		this->setOutputState(_indexNameMapDigitalOutRev[req.uri], req.state);
+
+		ros::Time start = ros::Time::now();
+		while((ros::Time::now().toSec() - start.toSec()) < 1.0)
 		{
+			_mutex.lock();
+			if(_outputChanged.updated == true)
+			{
+				_mutex.unlock();
+				break;
+			}
 			_mutex.unlock();
-			break;
+
+			ros::Duration(0.025).sleep();
 		}
+		_mutex.lock();
+		res.uri = _indexNameMapDigitalOut[_outputChanged.index];
+		res.state = _outputChanged.state;
+		ROS_DEBUG("Sending response: updated: %u, index: %d, state: %d",_outputChanged.updated, _outputChanged.index, _outputChanged.state);
+		ret = (_outputChanged.updated && (_outputChanged.index == _indexNameMapDigitalOutRev[req.uri]));
 		_mutex.unlock();
-
-		ros::Duration(0.025).sleep();
 	}
-	_mutex.lock();
-	res.uri = _indexNameMapDigitalOut[_outputChanged.index];
-	res.state = _outputChanged.state;
-	ROS_DEBUG("Sending response: updated: %u, index: %d, state: %d",_outputChanged.updated, _outputChanged.index, _outputChanged.state);
-	ret = (_outputChanged.updated && (_outputChanged.index == _indexNameMapDigitalOutRev[req.uri]));
-
-	_mutex.unlock();
+	else
+	{
+		ROS_DEBUG("Could not find uri '%s' inside port uri mapping", req.uri.c_str());
+		res.uri = req.uri;
+		res.state = req.state;
+		ret = false;
+	}
 
 	return ret;
 }
+
+auto PhidgetIKROS::onDigitalOutCallback(const cob_phidgets::DigitalSensorConstPtr& msg) -> void
+{
+	if(msg->uri.size() == msg->state.size())
+	{
+		for(size_t i = 0; i < msg->uri.size(); i++)
+		{
+			// this check is nessesary because [] operator on Maps inserts an element if it is not found
+			_indexNameMapRevItr = _indexNameMapDigitalOutRev.find(msg->uri[i]);
+			if(_indexNameMapRevItr != _indexNameMapDigitalOutRev.end())
+			{
+				ROS_INFO("Setting digital output %i to state %i", _indexNameMapDigitalOutRev[msg->uri[i]], msg->state[i]);
+				this->setOutputState(_indexNameMapDigitalOutRev[msg->uri[i]], msg->state[i]);
+			}
+			else
+				ROS_DEBUG("Could not find uri '%s' inside port uri mapping", msg->uri[i].c_str());
+		}
+	}
+	else
+	{
+		ROS_ERROR("Received message with different uri and state container sizes");
+	}
+}
+
 auto PhidgetIKROS::setDataRateCallback(cob_phidgets::SetDataRate::Request &req,
 										cob_phidgets::SetDataRate::Response &res) -> bool
 {
@@ -376,7 +409,7 @@ auto PhidgetIKROS::setTriggerValueCallback(cob_phidgets::SetTriggerValue::Reques
 auto PhidgetIKROS::attachHandler() -> int
 {
 	int serialNo, version, numInputs, numOutputs, millis;
-	int numSensors, triggerVal, ratiometric, i;
+	int numSensors, triggerVal, ratiometric;
 	const char *ptr, *name;
 
 	CPhidget_getDeviceName((CPhidgetHandle)_iKitHandle, &name);
@@ -397,7 +430,7 @@ auto PhidgetIKROS::attachHandler() -> int
 	ROS_DEBUG("Num Sensors: %d", numSensors);
 	ROS_DEBUG("Ratiometric: %d", ratiometric);
 
-	for(i = 0; i < numSensors; i++)
+	for(int i = 0; i < numSensors; i++)
 	{
 		CPhidgetInterfaceKit_getSensorChangeTrigger(_iKitHandle, i, &triggerVal);
 		CPhidgetInterfaceKit_getDataRate(_iKitHandle, i, &millis);

--- a/cob_phidgets/srv/SetDigitalSensor.srv
+++ b/cob_phidgets/srv/SetDigitalSensor.srv
@@ -1,5 +1,5 @@
-int8 index
+string uri
 int8 state
 ---
-int8 index
+string uri
 int8 state


### PR DESCRIPTION
+setting a digital output by a service call is now done by using the sensors uri instead of the phidgets index
+added a topic to change digital outputs (this is more generic for all digital sensors)
+some additional fixes
