### PR TITLE
Fixed cob_phidget startup crash

### DIFF
--- a/cob_phidgets/ros/config/phidget_config.yaml
+++ b/cob_phidgets/ros/config/phidget_config.yaml
@@ -2,53 +2,56 @@ frequency: 30                       #nodes update frequency in hz
 update_mode: polling                #switch between poll and event driven processing [polling, event]
 
 boards:                             
-  ifk_general:                      #phidget board with a name
+  ifk_grippers:                      #phidget board with a name
     serial_num: 272849              #phidget boards serial number
     ratiometric: true
     sensors:                        #configured sensors of this board
-       gripper_left_command:              #a sensor and name (URI) with which the Information will be published
-        type: digital_out           #type of the sensor [digital_out, digital_in, analog]
-        index: 0                    #port on which the information is physically connected to the phidget board
        gripper_left_hall_fingers:
         type: analog
-        index: 4
+        index: 3
        gripper_left_hall_x:
         type: analog
-        index: 5
+        index: 2
        gripper_left_hall_y:
         type: analog
-        index: 6
+        index: 1
        gripper_left_hall_z:
         type: analog
-        index: 7
-       gripper_right_command:              #a sensor and name (URI) with which the Information will be published
-        type: digital_out           #type of the sensor [digital_out, digital_in, analog]
-        index: 1                    #port on which the information is physically connected to the phidget board
+        index: 0
        gripper_right_hall_fingers:
         type: analog
-        index: 0
+        index: 7
        gripper_right_hall_x:
         type: analog
-        index: 1
+        index: 6
        gripper_right_hall_y:
         type: analog
-        index: 2
+        index: 5
        gripper_right_hall_z:
         type: analog
-        index: 3
+        index: 4
  
-  ifk_test: 
-    serial_num: 272745
+  ifk_general: 
+    serial_num: 285651
     ratiometric: true
     sensors:
-      gripper_open_close:
+      gripper_left_command:
         type: digital_out
-        index: 2
-      gripper_finger:
+        index: 1
+      gripper_right_command:
+        type: digital_out
+        index: 0
+      gripper_relayboard:
         type: analog
         index: 2
+      bat1: 
+        type: analog
+        index: 0
+      bat2: 
+        type: analog
+        index: 1
+      example1:
+        type: analog
+        index: 4
         change_trigger: 10          #the sensors change trigger value (only event driven mode)
         data_rate: 20               #ports data rate
-      em_stop_laser: 
-        type: digital_in
-        index: 1

--- a/cob_phidgets/ros/src/phidget_sensors_node.cpp
+++ b/cob_phidgets/ros/src/phidget_sensors_node.cpp
@@ -135,10 +135,11 @@ int main(int argc, char **argv)
 			phidget_params_map_itr = phidget_params_map.find(device.serial_num);
 			XmlRpc::XmlRpcValue *sensors_param = (phidget_params_map_itr != phidget_params_map.end()) ? &((*phidget_params_map_itr).second.second) : nullptr;
 			std::string name;
-			if(phidget_params_map_itr != phidget_params_map.end())
+			if(sensors_param != nullptr)
 				name = (*phidget_params_map_itr).second.first;
 			else
 			{
+				ROS_WARN("Could not find parameters for Board with serial: %d. Using default params!", device.serial_num);
 				std::stringstream ss; ss << device.serial_num;
 				name = ss.str();
 			}

--- a/cob_phidgets/ros/src/phidgetik_ros.cpp
+++ b/cob_phidgets/ros/src/phidgetik_ros.cpp
@@ -62,7 +62,6 @@
 PhidgetIKROS::PhidgetIKROS(ros::NodeHandle nh, int serial_num, std::string board_name, XmlRpc::XmlRpcValue* sensor_params, SensingMode mode)
 	:PhidgetIK(mode), _nh(nh), _serial_num(serial_num)
 {
-	ROS_DEBUG("PhidgetIKROS::PhidgetIKROS");
 	ros::NodeHandle tmpHandle("~");
 	ros::NodeHandle nodeHandle(tmpHandle, board_name);
 	_outputChanged.updated=false;
@@ -94,7 +93,6 @@ PhidgetIKROS::~PhidgetIKROS()
 
 auto PhidgetIKROS::readParams(XmlRpc::XmlRpcValue* sensor_params) -> void
 {
-	ROS_DEBUG("Reading Params");
 	if(sensor_params != nullptr)
 	{
 		for(auto& sensor : *sensor_params)

--- a/cob_phidgets/ros/src/phidgetik_ros.cpp
+++ b/cob_phidgets/ros/src/phidgetik_ros.cpp
@@ -62,6 +62,7 @@
 PhidgetIKROS::PhidgetIKROS(ros::NodeHandle nh, int serial_num, std::string board_name, XmlRpc::XmlRpcValue* sensor_params, SensingMode mode)
 	:PhidgetIK(mode), _nh(nh), _serial_num(serial_num)
 {
+	ROS_DEBUG("PhidgetIKROS::PhidgetIKROS");
 	ros::NodeHandle tmpHandle("~");
 	ros::NodeHandle nodeHandle(tmpHandle, board_name);
 	_outputChanged.updated=false;
@@ -93,47 +94,51 @@ PhidgetIKROS::~PhidgetIKROS()
 
 auto PhidgetIKROS::readParams(XmlRpc::XmlRpcValue* sensor_params) -> void
 {
-	for(auto& sensor : *sensor_params)
+	ROS_DEBUG("Reading Params");
+	if(sensor_params != nullptr)
 	{
-		std::string name = sensor.first;
-		XmlRpc::XmlRpcValue value = sensor.second;
-		if(!value.hasMember("type"))
+		for(auto& sensor : *sensor_params)
 		{
-			ROS_ERROR("Sensor Param '%s' has no 'type' member. Ignoring param!", name.c_str());
-			continue;
-		}
-		if(!value.hasMember("index"))
-		{
-			ROS_ERROR("Sensor Param '%s' has no 'index' member. Ignoring param!", name.c_str());
-			continue;
-		}
-		XmlRpc::XmlRpcValue value_type = value["type"];
-		XmlRpc::XmlRpcValue value_index = value["index"];
-		std::string type = value_type;
-		int index = value_index;
+			std::string name = sensor.first;
+			XmlRpc::XmlRpcValue value = sensor.second;
+			if(!value.hasMember("type"))
+			{
+				ROS_ERROR("Sensor Param '%s' has no 'type' member. Ignoring param!", name.c_str());
+				continue;
+			}
+			if(!value.hasMember("index"))
+			{
+				ROS_ERROR("Sensor Param '%s' has no 'index' member. Ignoring param!", name.c_str());
+				continue;
+			}
+			XmlRpc::XmlRpcValue value_type = value["type"];
+			XmlRpc::XmlRpcValue value_index = value["index"];
+			std::string type = value_type;
+			int index = value_index;
 
-		if(type == "analog")
-			_indexNameMapAnalog.insert(std::make_pair(index, name));
-		else if(type == "digital_in")
-			_indexNameMapDigitalIn.insert(std::make_pair(index, name));
-		else if(type == "digital_out")
-			_indexNameMapDigitalOut.insert(std::make_pair(index, name));
-		else
-			ROS_ERROR("Type '%s' in sensor param '%s' is unkown", type.c_str(), name.c_str());
+			if(type == "analog")
+				_indexNameMapAnalog.insert(std::make_pair(index, name));
+			else if(type == "digital_in")
+				_indexNameMapDigitalIn.insert(std::make_pair(index, name));
+			else if(type == "digital_out")
+				_indexNameMapDigitalOut.insert(std::make_pair(index, name));
+			else
+				ROS_ERROR("Type '%s' in sensor param '%s' is unkown", type.c_str(), name.c_str());
 
-		if(value.hasMember("change_trigger"))
-		{
-			XmlRpc::XmlRpcValue value_change_trigger = value["change_trigger"];
-			int change_trigger = value_change_trigger;
-			ROS_WARN("Setting change trigger to %d for sensor %s with index %d ",change_trigger, name.c_str(), index);
-			setSensorChangeTrigger(index, change_trigger);
-		}
-		if(value.hasMember("data_rate"))
-		{
-			XmlRpc::XmlRpcValue value_data_rate = value["data_rate"];
-			int data_rate = value_data_rate;
-			ROS_WARN("Setting data rate to %d for sensor %s with index %d ",data_rate, name.c_str(), index);
-			setDataRate(index, data_rate);
+			if(value.hasMember("change_trigger"))
+			{
+				XmlRpc::XmlRpcValue value_change_trigger = value["change_trigger"];
+				int change_trigger = value_change_trigger;
+				ROS_WARN("Setting change trigger to %d for sensor %s with index %d ",change_trigger, name.c_str(), index);
+				setSensorChangeTrigger(index, change_trigger);
+			}
+			if(value.hasMember("data_rate"))
+			{
+				XmlRpc::XmlRpcValue value_data_rate = value["data_rate"];
+				int data_rate = value_data_rate;
+				ROS_WARN("Setting data rate to %d for sensor %s with index %d ",data_rate, name.c_str(), index);
+				setDataRate(index, data_rate);
+			}
 		}
 	}
 	//fill up rest of maps with default values


### PR DESCRIPTION
cob_phidget crashed if there was no configuration on the param server for an attached board
