### PR TITLE
fixed cob_voltage_control groovy build

### DIFF
--- a/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
+++ b/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
@@ -10,7 +10,7 @@
 
 #include <cob_voltage_control_common.cpp>
 
-#include <libphidgets/phidget21.h>
+//#include <libphidgets/phidget21.h>
 
 
 


### PR DESCRIPTION
phidget21.h does not have a header guard. So this file should be included only one time.
