### PR TITLE
Fix python indentation problems

### DIFF
--- a/cob_relayboard/ros/src/new_method.py
+++ b/cob_relayboard/ros/src/new_method.py
@@ -54,9 +54,9 @@ class volts_filter():
 	
 if __name__ == '__main__':
     rospy.init_node('volt_filt')
-	vf = volts_filter()
-	
-	while not rospy.is_shutdown():
-		rospy.sleep(1.0)
+    vf = volts_filter()
+
+    while not rospy.is_shutdown():
+        rospy.sleep(1.0)
 
 


### PR DESCRIPTION
Causing python bytecompile failures on Fedora. Should be backported to Groovy.
