### PR TITLE
Automatica2014 SMErobotics reveting demo version

### DIFF
--- a/cob_phidgets/CMakeLists.txt
+++ b/cob_phidgets/CMakeLists.txt
@@ -48,7 +48,12 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-include_directories(${PROJECT_SOURCE_DIR}/ros/include ${PROJECT_SOURCE_DIR}/common/include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
+# Set to debug build
+#SET(CMAKE_BUILD_TYPE debug)
+
+include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/ros/include ${PROJECT_SOURCE_DIR}/common/include)
 
 
 add_executable(range_sensors ros/src/phidgets_range_sensors.cpp)
@@ -74,7 +79,13 @@ target_link_libraries(phidget_sensors ${catkin_LIBRARIES})
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS range_sensors phidget_sensors
+install(TARGETS range_sensors
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS phidget_sensors
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/cob_phidgets/CMakeLists.txt
+++ b/cob_phidgets/CMakeLists.txt
@@ -48,7 +48,12 @@ catkin_package(
 ###########
 ## Build ##
 ###########
-include_directories(${PROJECT_SOURCE_DIR}/ros/include ${PROJECT_SOURCE_DIR}/common/include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
+# Set to debug build
+#SET(CMAKE_BUILD_TYPE debug)
+
+include_directories(${Boost_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR}/ros/include ${PROJECT_SOURCE_DIR}/common/include)
 
 
 add_executable(range_sensors ros/src/phidgets_range_sensors.cpp)
@@ -73,7 +78,13 @@ target_link_libraries(phidget_sensors ${catkin_LIBRARIES})
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS range_sensors phidget_sensors
+install(TARGETS range_sensors
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(TARGETS phidget_sensors
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
+++ b/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
@@ -89,7 +89,8 @@ private:
 	ros::ServiceServer _srvDigitalIn;
 
 	int _serial_num;
-
+	std::string _board_name;
+	
 	struct OutputCompare
 	{
 		bool updated;

--- a/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
+++ b/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
@@ -86,7 +86,7 @@ private:
 	ros::ServiceServer _srvDigitalOut;
 	ros::ServiceServer _srvDataRate;
 	ros::ServiceServer _srvTriggerValue;
-    ros::ServiceServer _srvDigitalIn;
+	ros::ServiceServer _srvDigitalIn;
 
 	int _serial_num;
 
@@ -127,9 +127,8 @@ private:
 										cob_phidgets::SetDataRate::Response &res) -> bool;
 	auto setTriggerValueCallback(cob_phidgets::SetTriggerValue::Request &req,
 										cob_phidgets::SetTriggerValue::Response &res) -> bool;
-
-    auto getDigitalCallback(cob_phidgets::SetDigitalSensor::Request &req,
-                                        cob_phidgets::SetDigitalSensor::Response &res) -> bool;
+	auto getDigitalCallback(cob_phidgets::SetDigitalSensor::Request &req,
+										cob_phidgets::SetDigitalSensor::Response &res) -> bool;
 
 };
 #endif //_PHIDGETIK_H_

--- a/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
+++ b/cob_phidgets/ros/include/cob_phidgets/phidgetik_ros.h
@@ -86,9 +86,9 @@ private:
 	ros::ServiceServer _srvDigitalOut;
 	ros::ServiceServer _srvDataRate;
 	ros::ServiceServer _srvTriggerValue;
+    ros::ServiceServer _srvDigitalIn;
 
 	int _serial_num;
-	std::string _board_name;
 
 	struct OutputCompare
 	{
@@ -127,5 +127,9 @@ private:
 										cob_phidgets::SetDataRate::Response &res) -> bool;
 	auto setTriggerValueCallback(cob_phidgets::SetTriggerValue::Request &req,
 										cob_phidgets::SetTriggerValue::Response &res) -> bool;
+
+    auto getDigitalCallback(cob_phidgets::SetDigitalSensor::Request &req,
+                                        cob_phidgets::SetDigitalSensor::Response &res) -> bool;
+
 };
 #endif //_PHIDGETIK_H_

--- a/cob_phidgets/ros/src/phidgetik_ros.cpp
+++ b/cob_phidgets/ros/src/phidgetik_ros.cpp
@@ -76,7 +76,7 @@ PhidgetIKROS::PhidgetIKROS(ros::NodeHandle nh, int serial_num, std::string board
 	_srvDataRate = nodeHandle.advertiseService("set_data_rate", &PhidgetIKROS::setDataRateCallback, this);
 	_srvTriggerValue = nodeHandle.advertiseService("set_trigger_value", &PhidgetIKROS::setTriggerValueCallback, this);
 
-    _srvDigitalIn = nodeHandle.advertiseService("get_digital", &PhidgetIKROS::getDigitalCallback, this);
+	_srvDigitalIn = nodeHandle.advertiseService("get_digital", &PhidgetIKROS::getDigitalCallback, this);
 
 	if(init(_serial_num) != EPHIDGET_OK)
 	{
@@ -224,7 +224,7 @@ auto PhidgetIKROS::update() -> void
 		if(_indexNameMapItr != _indexNameMapDigitalIn.end())
 			name = (*_indexNameMapItr).second;
 		names.push_back(name);
-        states.push_back(!this->getInputState(i)); // Inverted by the board for unknown reasons
+		states.push_back(!this->getInputState(i)); // Inverted by the board for unknown reasons
 	}
 	msg_digit.header.stamp = ros::Time::now();
 	msg_digit.uri = names;
@@ -330,7 +330,7 @@ auto PhidgetIKROS::sensorChangeHandler(int index, int sensorValue) -> int
 auto PhidgetIKROS::setDigitalOutCallback(cob_phidgets::SetDigitalSensor::Request &req,
 										cob_phidgets::SetDigitalSensor::Response &res) -> bool
 {
-    bool ret = false;
+	bool ret = false;
 	_mutex.lock();
 	_outputChanged.updated=false;
 	_outputChanged.index=-1;
@@ -342,14 +342,14 @@ auto PhidgetIKROS::setDigitalOutCallback(cob_phidgets::SetDigitalSensor::Request
 	if(_indexNameMapRevItr != _indexNameMapDigitalOutRev.end())
 	{
 		ROS_INFO("Setting digital output %i to state %i", _indexNameMapDigitalOutRev[req.uri], req.state);
-        int lastError = this->setOutputState(_indexNameMapDigitalOutRev[req.uri], req.state);
+		int lastError = this->setOutputState(_indexNameMapDigitalOutRev[req.uri], req.state);
 
-        if (lastError != EPHIDGET_OK)
-        {
-            ROS_ERROR("Phidget Error: %i (look up in phidget header file phidget21.h)", lastError);
-        }
+		if (lastError != EPHIDGET_OK)
+		{
+			ROS_ERROR("Phidget Error: %i (look up in phidget header file phidget21.h)", lastError);
+		}
 
-        ros::Time start = ros::Time::now();
+		ros::Time start = ros::Time::now();
 		while((ros::Time::now().toSec() - start.toSec()) < 1.0)
 		{
 			_mutex.lock();
@@ -363,11 +363,11 @@ auto PhidgetIKROS::setDigitalOutCallback(cob_phidgets::SetDigitalSensor::Request
 			ros::Duration(0.025).sleep();
 		}
 		_mutex.lock();
-        res.uri = req.uri;
-        res.state = this->getOutputState(_indexNameMapDigitalOutRev[req.uri]);// _outputChanged.state;
+		res.uri = req.uri;
+		res.state = this->getOutputState(_indexNameMapDigitalOutRev[req.uri]);// _outputChanged.state;
 		ROS_DEBUG("Sending response: updated: %u, index: %d, state: %d",_outputChanged.updated, _outputChanged.index, _outputChanged.state);
-        _mutex.unlock();
-        ret = (lastError == EPHIDGET_OK && res.state == req.state);
+		_mutex.unlock();
+		ret = (lastError == EPHIDGET_OK && res.state == req.state);
 
 	}
 	else
@@ -382,38 +382,38 @@ auto PhidgetIKROS::setDigitalOutCallback(cob_phidgets::SetDigitalSensor::Request
 }
 
 auto PhidgetIKROS::getDigitalCallback(cob_phidgets::SetDigitalSensor::Request &req,
-                                        cob_phidgets::SetDigitalSensor::Response &res) -> bool
+									cob_phidgets::SetDigitalSensor::Response &res) -> bool
 {
-    bool ret = false;
-    res.uri = req.uri;
-    res.state = -1;
+	bool ret = false;
+	res.uri = req.uri;
+	res.state = -1;
 
-    // this check is nessesary because [] operator on Maps inserts an element if it is not found
-    _indexNameMapRevItr = _indexNameMapDigitalInRev.find(req.uri);
-    if(_indexNameMapRevItr != _indexNameMapDigitalInRev.end())
-    {
-        ROS_DEBUG("Getting digital input %i value", _indexNameMapDigitalInRev[req.uri]);
+	// this check is nessesary because [] operator on Maps inserts an element if it is not found
+	_indexNameMapRevItr = _indexNameMapDigitalInRev.find(req.uri);
+	if(_indexNameMapRevItr != _indexNameMapDigitalInRev.end())
+	{
+		ROS_DEBUG("Getting digital input %i value", _indexNameMapDigitalInRev[req.uri]);
 
-        res.state = !this->getInputState(_indexNameMapDigitalInRev[req.uri]); // inverted by the board for unknown reasons
-        ret = true;
-    }
-    else
-    {
-        _indexNameMapRevItr = _indexNameMapDigitalOutRev.find(req.uri);
-        if(_indexNameMapRevItr != _indexNameMapDigitalOutRev.end())
-        {
-            ROS_DEBUG("Getting digital output %i value", _indexNameMapDigitalOutRev[req.uri]);
+		res.state = !this->getInputState(_indexNameMapDigitalInRev[req.uri]); // inverted by the board for unknown reasons
+		ret = true;
+	}
+	else
+	{
+		_indexNameMapRevItr = _indexNameMapDigitalOutRev.find(req.uri);
+		if(_indexNameMapRevItr != _indexNameMapDigitalOutRev.end())
+		{
+			ROS_DEBUG("Getting digital output %i value", _indexNameMapDigitalOutRev[req.uri]);
 
-            res.state = this->getOutputState(_indexNameMapDigitalOutRev[req.uri]);
-            ret = true;
-        }
-        else
-        {
-            ROS_DEBUG("Could not find uri '%s' inside port uri mapping", req.uri.c_str());
-            ret = false;
-        }
-    }
-    return ret;
+			res.state = this->getOutputState(_indexNameMapDigitalOutRev[req.uri]);
+			ret = true;
+		}
+		else
+		{
+			ROS_DEBUG("Could not find uri '%s' inside port uri mapping", req.uri.c_str());
+			ret = false;
+		}
+	}
+	return ret;
 }
 
 
@@ -492,10 +492,10 @@ auto PhidgetIKROS::attachHandler() -> int
 auto PhidgetIKROS::detachHandler() -> int
 {
 	int serial_number;
-    const char *device_name;
+	const char *device_name;
 
-    CPhidget_getDeviceName ((CPhidgetHandle)_iKitHandle, &device_name);
-    CPhidget_getSerialNumber((CPhidgetHandle)_iKitHandle, &serial_number);
-    ROS_INFO("%s Serial number %d detached!", device_name, serial_number);
-    return 0;
+	CPhidget_getDeviceName ((CPhidgetHandle)_iKitHandle, &device_name);
+	CPhidget_getSerialNumber((CPhidgetHandle)_iKitHandle, &serial_number);
+	ROS_INFO("%s Serial number %d detached!", device_name, serial_number);
+	return 0;
 }

--- a/cob_phidgets/ros/src/phidgetik_ros.cpp
+++ b/cob_phidgets/ros/src/phidgetik_ros.cpp
@@ -60,7 +60,7 @@
 #include <cob_phidgets/phidgetik_ros.h>
 
 PhidgetIKROS::PhidgetIKROS(ros::NodeHandle nh, int serial_num, std::string board_name, XmlRpc::XmlRpcValue* sensor_params, SensingMode mode)
-	:PhidgetIK(mode), _nh(nh), _serial_num(serial_num)
+	:PhidgetIK(mode), _nh(nh), _serial_num(serial_num), _board_name(board_name)
 {
 	ros::NodeHandle tmpHandle("~");
 	ros::NodeHandle nodeHandle(tmpHandle, board_name);
@@ -149,7 +149,7 @@ auto PhidgetIKROS::readParams(XmlRpc::XmlRpcValue* sensor_params) -> void
 		if(_indexNameMapItr == _indexNameMapDigitalIn.end())
 		{
 			std::stringstream ss;
-			ss << getDeviceSerialNumber() << "/" << "in/" << i;
+			ss << _board_name << "/" << "in/" << i;
 			_indexNameMapDigitalIn.insert(std::make_pair(i, ss.str()));
 		}
 	}
@@ -160,7 +160,7 @@ auto PhidgetIKROS::readParams(XmlRpc::XmlRpcValue* sensor_params) -> void
 		if(_indexNameMapItr == _indexNameMapDigitalOut.end())
 		{
 			std::stringstream ss;
-			ss << getDeviceSerialNumber() << "/" << "out/" << i;
+			ss << _board_name << "/" << "out/" << i;
 			_indexNameMapDigitalOut.insert(std::make_pair(i, ss.str()));
 		}
 	}
@@ -171,7 +171,7 @@ auto PhidgetIKROS::readParams(XmlRpc::XmlRpcValue* sensor_params) -> void
 		if(_indexNameMapItr == _indexNameMapAnalog.end())
 		{
 			std::stringstream ss;
-			ss << getDeviceSerialNumber() << "/" << i;
+			ss << _board_name << "/" << i;
 			_indexNameMapAnalog.insert(std::make_pair(i, ss.str()));
 		}
 	}
@@ -184,7 +184,7 @@ auto PhidgetIKROS::readParams(XmlRpc::XmlRpcValue* sensor_params) -> void
 		if(_indexNameMapItr != _indexNameMapDigitalIn.end())
 		{
 			std::stringstream ss;
-			ss << getDeviceSerialNumber() << "/" << "in/" << i;
+			ss << _board_name << "/" << "in/" << i;
 
 			_indexNameMapDigitalInRev.insert(std::make_pair(_indexNameMapDigitalIn[i],i));
 		}
@@ -275,7 +275,7 @@ auto PhidgetIKROS::update() -> void
 
 auto PhidgetIKROS::inputChangeHandler(int index, int inputState) -> int
 {
-	ROS_DEBUG("Board %d: Digital Input %d changed to State: %d", _serial_num, index, inputState);
+	ROS_DEBUG("Board %d: Digital Input %d changed to State: %d", _board_name.c_str(), index, inputState);
 	cob_phidgets::DigitalSensor msg;
 	std::vector<std::string> names;
 	std::vector<signed char> states;
@@ -297,7 +297,7 @@ auto PhidgetIKROS::inputChangeHandler(int index, int inputState) -> int
 
 auto PhidgetIKROS::outputChangeHandler(int index, int outputState) -> int
 {
-	ROS_DEBUG("Board %d: Digital Output %d changed to State: %d", _serial_num, index, outputState);
+	ROS_DEBUG("Board %d: Digital Output %d changed to State: %d", _board_name.c_str(), index, outputState);
 	std::lock_guard<std::mutex> lock{_mutex};
 	_outputChanged.updated = true;
 	_outputChanged.index = index;
@@ -306,7 +306,7 @@ auto PhidgetIKROS::outputChangeHandler(int index, int outputState) -> int
 }
 auto PhidgetIKROS::sensorChangeHandler(int index, int sensorValue) -> int
 {
-	ROS_DEBUG("Board %d: Analog Input %d changed to Value: %d", _serial_num, index, sensorValue);
+	ROS_DEBUG("Board %d: Analog Input %d changed to Value: %d", _board_name.c_str(), index, sensorValue);
 	cob_phidgets::AnalogSensor msg;
 	std::vector<std::string> names;
 	std::vector<short int> values;

--- a/cob_phidgets/ros/src/phidgets_range_sensors.cpp
+++ b/cob_phidgets/ros/src/phidgets_range_sensors.cpp
@@ -21,7 +21,9 @@ public:
 	Sensor(const std::string &fr_id, const int id, const int filter_size = 10) :
 			id_(id), filter_size_(filter_size), frame_id_(fr_id)
 	{
-		pub_range_ = n_.advertise<sensor_msgs::Range>(frame_id_, 0);
+		char buffer[256];
+		sprintf(buffer, "range_%d", id);
+		pub_range_ = n_.advertise<sensor_msgs::Range>(buffer, 0);
 	}
 
 	void publish()


### PR DESCRIPTION
FIX: Somewhere in reading digitals the value was inverted. I change that a high output is read as a high input if there are shortcut.
FIX: If an output is requested to change its state but it is already its state, this version will not return an error.
ADD: An additional srvs that allows checking for exactly one state. Can be used instead of parsing the topic.

This version worked fine on Automatica2014. It is originally based on bnm's fork
