### PR TITLE
Can peak sys usb extension

### DIFF
--- a/cob_generic_can/common/include/cob_generic_can/CanESD.h
+++ b/cob_generic_can/common/include/cob_generic_can/CanESD.h
@@ -92,6 +92,7 @@ private:
 public:
 	CanESD(const char* cIniFile, bool bObjectMode = false);
 	~CanESD();
+	bool init_ret();
 	void init(){};
 	bool transmitMsg(CanMsg CMsg, bool bBlocking = true);
 	bool receiveMsgRetry(CanMsg* pCMsg, int iNrOfRetry);

--- a/cob_generic_can/common/include/cob_generic_can/CanItf.h
+++ b/cob_generic_can/common/include/cob_generic_can/CanItf.h
@@ -8,8 +8,8 @@
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  *
  * Project name: care-o-bot
- * ROS stack name: cob3_common
- * ROS package name: generic_can
+ * ROS stack name: cob_driver
+ * ROS package name: cob_generic_can
  * Description:
  *								
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -58,6 +58,21 @@
 #include <cob_generic_can/CanMsg.h>
 //-----------------------------------------------
 
+// for types and baudrates see: https://github.com/ipa320/cob_robots/blob/hydro_dev/cob_hardware_config/raw3-5/config/base/CanCtrl.ini
+#define CANITFTYPE_CAN_PEAK		0
+#define CANITFTYPE_CAN_PEAK_USN	1
+#define CANITFTYPE_CAN_ESD		2
+#define CANITFTYPE_CAN_DUMMY	3
+#define CANITFTYPE_CAN_BECKHOFF	4
+
+#define CANITFBAUD_1M 	0x0
+#define CANITFBAUD_500K	0x2
+#define CANITFBAUD_250K 0x4
+#define CANITFBAUD_125K	0x6
+#define CANITFBAUD_50K	0x9
+#define CANITFBAUD_20K	0xB
+#define CANITFBAUD_10K	0xD
+
 /**
  * General interface of the CAN bus.
  * \ingroup DriversCanModul	
@@ -79,6 +94,11 @@ public:
 	 */
 	virtual ~CanItf() {
 	}
+	
+	/**
+	 * Initializes the CAN bus and returns success.
+	 */
+	virtual bool init_ret() = 0;
 	
 	/**
 	 * Initializes the CAN bus.

--- a/cob_generic_can/common/include/cob_generic_can/CanPeakSys.h
+++ b/cob_generic_can/common/include/cob_generic_can/CanPeakSys.h
@@ -66,6 +66,7 @@ public:
 	// --------------- Interface
 	CanPeakSys(const char* cIniFile);
 	~CanPeakSys();
+	bool init_ret();
 	void init();
 	void destroy() {}
 	bool transmitMsg(CanMsg CMsg, bool bBlocking = true);

--- a/cob_generic_can/common/include/cob_generic_can/CanPeakSysUSB.h
+++ b/cob_generic_can/common/include/cob_generic_can/CanPeakSysUSB.h
@@ -2,7 +2,7 @@
  *
  * Copyright (c) 2010
  *
- * Fraunhofer Institute for Manufacturing Engineering	
+ * Fraunhofer Institute for Manufacturing Engineering
  * and Automation (IPA)
  *
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -11,9 +11,9 @@
  * ROS stack name: cob_drivers
  * ROS package name: cob_generic_can
  * Description:
- *								
+ *
  * +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- *			
+ *
  * Author: Christian Connette, email:christian.connette@ipa.fhg.de
  * Supervised by: Christian Connette, email:christian.connette@ipa.fhg.de
  *
@@ -30,23 +30,23 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the Fraunhofer Institute for Manufacturing 
+ *     * Neither the name of the Fraunhofer Institute for Manufacturing
  *       Engineering and Automation (IPA) nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License LGPL as 
- * published by the Free Software Foundation, either version 3 of the 
+ * it under the terms of the GNU Lesser General Public License LGPL as
+ * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License LGPL for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
- * License LGPL along with this program. 
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License LGPL along with this program.
  * If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************/
@@ -63,8 +63,10 @@ class CANPeakSysUSB : public CanItf
 {
 public:
 	// --------------- Interface
+	CANPeakSysUSB(const char* device, int baudrate);
 	CANPeakSysUSB(const char* cIniFile);
 	~CANPeakSysUSB();
+	bool init_ret();
 	void init();
 	void destroy() {};
 	bool transmitMsg(CanMsg CMsg, bool bBlocking = true);
@@ -75,17 +77,18 @@ public:
 private:
 	// --------------- Types
 	HANDLE m_handle;
-	
+
 	bool m_bInitialized;
 	IniFile m_IniFile;
 	bool m_bSimuEnabled;
+	const char* p_cDevice;
 	int m_iBaudrateVal;
 
 	static const int c_iInterrupt;
 	static const int c_iPort;
-	
+
 	bool initCAN();
-	
+
 	void outputDetailedStatus();
 };
 //-----------------------------------------------

--- a/cob_generic_can/common/src/CanESD.cpp
+++ b/cob_generic_can/common/src/CanESD.cpp
@@ -79,6 +79,12 @@ CanESD::~CanESD()
 	canClose(m_Handle);
 }
 
+//-----------------------------------------------
+bool CanESD::init_ret()
+{
+	// Not implemented yet
+	return false;
+}
 
 //-----------------------------------------------
 void CanESD::initIntern()

--- a/cob_generic_can/common/src/CanPeakSys.cpp
+++ b/cob_generic_can/common/src/CanPeakSys.cpp
@@ -84,6 +84,13 @@ CanPeakSys::~CanPeakSys()
 }
 
 //-----------------------------------------------
+bool CanPeakSys::init_ret()
+{
+	// Not implemented yet
+	return false;
+}
+
+//-----------------------------------------------
 void CanPeakSys::init()
 {
  std::string sCanDevice; 


### PR DESCRIPTION
Since cob_utilities package is [deprecated](https://raw.githubusercontent.com/iirob/cob_driver/hydro_dev/cob_utilities/package.xml) and in the future "IniFile.h"-files will be removed there is extension of can_generic package to enable set parameters in constructor.

the extension is fully implemented and tested for PEAK-Sys USB dongle, for other CAN devices empty functions are written since I don't have this hardware and can't test them.
