### PR TITLE
[light] new feature SweepMode

### DIFF
--- a/cob_light/common/include/sweepColorMode.h
+++ b/cob_light/common/include/sweepColorMode.h
@@ -1,0 +1,73 @@
+
+#ifndef SWEEPCOLORMODE_H
+#define SWEEPCOLORMODE_H
+
+#include <mode.h>
+#include <algorithm>
+
+class SweepColorMode : public Mode
+{
+public:
+   SweepColorMode(std::vector<color::rgba> colors, size_t num_leds, int priority = 0, double freq = 5, int pulses = 0, double timeout = 0)
+    :Mode(priority, freq, pulses, timeout), _toggle(false), _timer_inc(0), _num_leds(num_leds)
+  {
+    _colors = colors;
+    
+    _startcolor.r = 0.0;
+    _startcolor.g = 0.4;
+    _startcolor.b = 0.28;
+    _startcolor.a = 1.0;
+    if(_colors.size() == 1)
+      _startcolor = _colors[0];
+    _colors.resize(_num_leds);
+    if(_num_leds%2 == 0)
+    {
+      _colors[_num_leds/2] = _startcolor;
+      _colors[_num_leds/2-1] = _startcolor;
+    }
+    else
+      _colors[_num_leds/2] = _startcolor;
+    _pos = 0;
+
+    _inc = (1. / UPDATE_RATE_HZ) * _freq;
+  }
+
+  void execute()
+  {
+    if(_timer_inc >= 1.0)
+    {
+      for(int i = _num_leds/2; i < _num_leds; i++)
+      {
+        _colors[i].a *= 0.7;
+      }
+      for(int i = _num_leds/2-1; i >= 0; i--)
+      {
+        _colors[i].a *= 0.7;
+      }
+      _colors[(_num_leds/2)+_pos] = _startcolor;
+      _colors[(_num_leds/2)-1-_pos] = _startcolor;
+
+      _pos++;
+      if(_pos >= (_num_leds/2))
+        _pos = 0;
+
+      _pulsed++;
+      m_sigColorsReady(_colors);
+      _timer_inc = 0.0;
+    }
+    else
+      _timer_inc += _inc;
+  }
+
+  std::string getName(){ return std::string("CircleColorMode"); }
+
+private:
+  bool _toggle;
+  double _timer_inc;
+  double _inc;
+  size_t _num_leds;
+  int _pos;
+  color::rgba _startcolor;
+};
+
+#endif

--- a/cob_light/common/include/sweepColorMode.h
+++ b/cob_light/common/include/sweepColorMode.h
@@ -59,7 +59,7 @@ public:
       _timer_inc += _inc;
   }
 
-  std::string getName(){ return std::string("CircleColorMode"); }
+  std::string getName(){ return std::string("SweepColorMode"); }
 
 private:
   bool _toggle;

--- a/cob_light/common/src/modeFactory.cpp
+++ b/cob_light/common/src/modeFactory.cpp
@@ -60,6 +60,7 @@
 #include <fadeColorMode.h>
 #include <sequenceMode.h>
 #include <circleColorMode.h>
+#include <sweepColorMode.h>
 
 ModeFactory::ModeFactory()
 {
@@ -126,13 +127,13 @@ Mode* ModeFactory::create(cob_light::LightMode requestMode, IColorO* colorO)
 
 		case cob_light::LightMode::CIRCLE_COLORS:
 		{
-	std::cout<<"Factory generting Circle_Colors";
+        std::cout<<"Factory generting Circle_Colors";
         std::vector<color::rgba> colors;
         if(requestMode.colors.empty())
-	{
-	  std::cout<<"Colors is empty"<<std::endl;
+        {
+	        std::cout<<"Colors is empty"<<std::endl;
           colors.push_back(color);
-	}
+        }
         else
         {
           for(size_t i = 0; i < requestMode.colors.size(); i++)
@@ -141,12 +142,36 @@ Mode* ModeFactory::create(cob_light::LightMode requestMode, IColorO* colorO)
             color.g = requestMode.colors[i].g;
             color.b = requestMode.colors[i].b;
             color.a = requestMode.colors[i].a;
-	    colors.push_back(color);
+            colors.push_back(color);
           }
         }
 		    mode = new CircleColorMode(colors, colorO->getNumLeds(), requestMode.priority, requestMode.frequency, requestMode.pulses, requestMode.timeout);
 		}
 		break;
+
+    case cob_light::LightMode::SWEEP:
+    {
+        std::cout<<"Factory generting Sweep Colors";
+        std::vector<color::rgba> colors;
+        if(requestMode.colors.empty())
+        {
+          std::cout<<"Colors is empty"<<std::endl;
+          colors.push_back(color);
+        }
+        else
+        {
+          for(size_t i = 0; i < requestMode.colors.size(); i++)
+          {
+            color.r = requestMode.colors[i].r;
+            color.g = requestMode.colors[i].g;
+            color.b = requestMode.colors[i].b;
+            color.a = requestMode.colors[i].a;
+            colors.push_back(color);
+          }
+        }
+        mode = new SweepColorMode(colors, colorO->getNumLeds(), requestMode.priority, requestMode.frequency, requestMode.pulses, requestMode.timeout);
+    }
+    break;
 
 		default:
 			mode = NULL;
@@ -206,6 +231,10 @@ int ModeFactory::type(Mode *mode)
 		ret = cob_light::LightMode::FADE_COLOR;
   else if(dynamic_cast<SequenceMode*>(mode) != NULL)
     ret = cob_light::LightMode::SEQ;
+  else if(dynamic_cast<CircleColorMode*>(mode) != NULL)
+    ret = cob_light::LightMode::CIRCLE_COLORS;
+  else if(dynamic_cast<SweepColorMode*>(mode) != NULL)
+    ret = cob_light::LightMode::SWEEP;
 	else
 		ret = cob_light::LightMode::NONE;
 

--- a/cob_light/common/src/modeFactory.cpp
+++ b/cob_light/common/src/modeFactory.cpp
@@ -149,11 +149,9 @@ Mode* ModeFactory::create(cob_light::LightMode requestMode, IColorO* colorO)
 
     case cob_light::LightMode::SWEEP:
     {
-        std::cout<<"Factory generting Sweep Colors";
         std::vector<color::rgba> colors;
         if(requestMode.colors.empty())
         {
-          std::cout<<"Colors is empty"<<std::endl;
           colors.push_back(color);
         }
         else

--- a/cob_light/msg/LightMode.msg
+++ b/cob_light/msg/LightMode.msg
@@ -9,6 +9,7 @@ uint8 FADE_COLOR =     5           # will fade the colors in rainbow
 uint8 SEQ =            6           # executes one sequence after another as definied in sequences array
 uint8 CIRCLE_COLORS =  7           # circle through specific colors, if one color is set only one color will circle
                                    # if more than one color is set, that this colors will circle through
+uint8 SWEEP =          8           # circle color from front to back on both sides
 
 std_msgs/ColorRGBA     color       #the color which will be used
 float32                frequency   # in Hz

--- a/cob_light/msg/LightMode.msg
+++ b/cob_light/msg/LightMode.msg
@@ -21,3 +21,4 @@ int8                   priority    # priority [-20,20] default = 0. Modes with s
                                    # be executed.
 std_msgs/ColorRGBA[]   colors      # array of colors for setting all the LEDs
 cob_light/Sequence[]   sequences   # an array of sequence definitions, used only if mode is set to SEQ
+


### PR DESCRIPTION
added new Mode to cob_light driver.
This mode starts lighting the leds on the front of the robot and goes smoothly on both sides to the back.

Note: this PR is build on top of #220 so first accept #220 
