### PR TITLE
Feature/scanner standby indigo

### DIFF
--- a/cob_sick_s300/CMakeLists.txt
+++ b/cob_sick_s300/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_sick_s300)
 
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs diagnostic_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs diagnostic_msgs)
 
 ###################################
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-    CATKIN_DEPENDS roscpp sensor_msgs diagnostic_msgs
+    CATKIN_DEPENDS roscpp sensor_msgs std_msgs diagnostic_msgs
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )

--- a/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
+++ b/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
@@ -101,7 +101,6 @@
  *	   --> Telegram length (read from telegram) is 1104 bytes (iDataLength)
  *
  *	   if the scanner is in standby, the measurements are 0x4004 according to the Sick Support
- *	   (we better check 0x0440 as well to be on the safe side)
  */
 
 class ScannerSickS300

--- a/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
+++ b/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
@@ -99,6 +99,9 @@
  *	   --> Headerlength = 24 bytes (iHeaderLength)
  *	   --> Total length in buffer is 1108 bytes
  *	   --> Telegram length (read from telegram) is 1104 bytes (iDataLength)
+ *
+ *	   if the scanner is in standby, the measurements are 0x4004 according to the Sick Support
+ *	   (we better check 0x0440 as well to be on the safe side)
  */
 
 class ScannerSickS300
@@ -153,6 +156,9 @@ public:
 	void stopScanner();
 	//sick_lms.Uninitialize();
 
+	// whether the scanner is currently in Standby or not
+	bool isInStandby() {return m_bInStandby;};
+
 	void purgeScanBuf();
 
 	bool getScan(std::vector<double> &vdDistanceM, std::vector<double> &vdAngleRAD, std::vector<double> &vdIntensityAU, unsigned int &iTimestamp, unsigned int &iTimeNow, const bool debug);
@@ -177,6 +183,7 @@ private:
 	int m_iPosReadBuf2;
 	static unsigned char m_iScanId;
 	int m_actualBufferSize;
+	bool m_bInStandby;
 
 	// Components
 	SerialIO m_SerialIO;

--- a/cob_sick_s300/common/src/ScannerSickS300.cpp
+++ b/cob_sick_s300/common/src/ScannerSickS300.cpp
@@ -123,6 +123,8 @@ ScannerSickS300::ScannerSickS300()
 	
 	m_actualBufferSize = 0;
 
+	m_bInStandby = true;
+
 }
 
 
@@ -190,7 +192,6 @@ void ScannerSickS300::stopScanner()
 {
 }
 
-
 //-----------------------------------------------
 bool ScannerSickS300::getScan(std::vector<double> &vdDistanceM, std::vector<double> &vdAngleRAD, std::vector<double> &vdIntensityAU, unsigned int &iTimestamp, unsigned int &iTimeNow, const bool debug)
 {
@@ -257,13 +258,19 @@ void ScannerSickS300::convertScanToPolar(const PARAM_MAP::const_iterator param, 
 	double dDist;
 	double dAngle, dAngleStep;
 	double dIntens;
+	bool bInStandby = true;
 
 	vecScanPolar.resize(viScanRaw.size());
 	dAngleStep = fabs(param->second.dStopAngle - param->second.dStartAngle) / double(viScanRaw.size() - 1) ;
 	
+
 	for(size_t i=0; i<viScanRaw.size(); i++)
 	{
 		dDist = double ((viScanRaw[i] & 0x1FFF) * param->second.dScale);
+
+		// if not all values are 0x4004 (or 0x0440), we are not in standby
+		if (!((viScanRaw[i] == 0x4004) || (viScanRaw[i] == 0x0440)))
+			bInStandby = false;
 
 		dAngle = param->second.dStartAngle + i*dAngleStep;
 		dIntens = double(viScanRaw[i] & 0x2000);
@@ -272,4 +279,6 @@ void ScannerSickS300::convertScanToPolar(const PARAM_MAP::const_iterator param, 
 		vecScanPolar[i].da = dAngle;
 		vecScanPolar[i].di = dIntens;
 	}
+
+	m_bInStandby = bInStandby;
 }

--- a/cob_sick_s300/common/src/ScannerSickS300.cpp
+++ b/cob_sick_s300/common/src/ScannerSickS300.cpp
@@ -268,8 +268,8 @@ void ScannerSickS300::convertScanToPolar(const PARAM_MAP::const_iterator param, 
 	{
 		dDist = double ((viScanRaw[i] & 0x1FFF) * param->second.dScale);
 
-		// if not all values are 0x4004 (or 0x0440), we are not in standby
-		if (!((viScanRaw[i] == 0x4004) || (viScanRaw[i] == 0x0440)))
+		// if not all values are 0x4004 , we are not in standby
+		if ( !(viScanRaw[i] == 0x4004) )
 			bInStandby = false;
 
 		dAngle = param->second.dStartAngle + i*dAngleStep;

--- a/cob_sick_s300/package.xml
+++ b/cob_sick_s300/package.xml
@@ -14,9 +14,11 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
 
   <export>

--- a/cob_sick_s300/ros/src/cob_sick_s300.cpp
+++ b/cob_sick_s300/ros/src/cob_sick_s300.cpp
@@ -101,6 +101,7 @@ class NodeClass
 		
 		// global variables
 		std::string port;
+		std::string node_name;
 		int baud, scan_id, publish_frequency;
 		bool inverted;
 		double scan_duration, scan_cycle_time;
@@ -195,6 +196,8 @@ class NodeClass
 			syncedROSTime = ros::Time::now();
 			syncedTimeReady = false;
 
+			node_name = ros::this_node::getName();
+
 			// implementation of topics to publish
 			topicPub_LaserScan = nh.advertise<sensor_msgs::LaserScan>("scan", 1);
 			topicPub_InStandby = nh.advertise<std_msgs::Bool>("scan_standby", 1);
@@ -210,16 +213,20 @@ class NodeClass
 		void receiveScan() {
 			std::vector< double > ranges, rangeAngles, intensities;
 			unsigned int iSickTimeStamp, iSickNow;
-			if(scanner_.isInStandby())
+
+			if(scanner_.getScan(ranges, rangeAngles, intensities, iSickTimeStamp, iSickNow, debug_))
 			{
-				publishWarn("scanner in standby");
-				ROS_WARN_THROTTLE(30, "scanner on port %s in standby", port.c_str());
-				publishStandby(true);
-			}
-			else if(scanner_.getScan(ranges, rangeAngles, intensities, iSickTimeStamp, iSickNow, debug_))
-			{
-				publishStandby(false);
-				publishLaserScan(ranges, rangeAngles, intensities, iSickTimeStamp, iSickNow);
+				if(scanner_.isInStandby())
+				{
+					publishWarn("scanner in standby");
+					ROS_WARN_THROTTLE(30, "scanner %s on port %s in standby", node_name.c_str(), port.c_str());
+					publishStandby(true);
+				}
+				else
+				{
+					publishStandby(false);
+					publishLaserScan(ranges, rangeAngles, intensities, iSickTimeStamp, iSickNow);
+				}
 			}
 		}
 		


### PR DESCRIPTION
This is the same as #227 but now for indigo.

This PR introduces a check for whether the scanner is in standby into the driver.
This is signaled through a std_msgs::Bool topic.
If the scanner is in standby, it additionally publishes a throttled diagnostic msg.

The check is done by checking all scanner values for the bitflag 0x4004. It is the only way to check this without configuring the scanner differently and evaluating the I/O-protocol.

@ipa-josh 
