### PR TITLE
Sound error, cepstral needs alsa oss

### DIFF
--- a/cob_mimic/CMakeLists.txt
+++ b/cob_mimic/CMakeLists.txt
@@ -15,7 +15,7 @@ add_action_files(DIRECTORY action FILES
 generate_messages(DEPENDENCIES actionlib_msgs)
 
 catkin_package(
-  CATKIN_DEPENDS actionlib_msgs actionlib message_runtime rospy std_msgs
+  CATKIN_DEPENDS actionlib_msgs actionlib message_runtime roslib rospy std_msgs
 )
 
 ### INSTALL ###

--- a/cob_mimic/package.xml
+++ b/cob_mimic/package.xml
@@ -20,6 +20,7 @@
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>roslib</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
 

--- a/cob_mimic/src/mimic_node.py
+++ b/cob_mimic/src/mimic_node.py
@@ -61,6 +61,7 @@ import sys
 import os
 import subprocess
 
+import roslib
 import rospy
 import actionlib
 

--- a/cob_sound/CMakeLists.txt
+++ b/cob_sound/CMakeLists.txt
@@ -10,7 +10,7 @@ add_action_files(DIRECTORY action FILES
 )
 
 generate_messages(
-  DEPENDENCIES actionlib_msgs std_msgs
+  DEPENDENCIES actionlib_msgs
 )
 
 catkin_package(

--- a/cob_sound/ros/src/sound.cpp
+++ b/cob_sound/ros/src/sound.cpp
@@ -136,7 +136,7 @@ public:
     nh_.param<std::string>("/sound_controller/cepstral_settings",cepstral_conf,"\"speech/rate=170\"");
     if (mode == "cepstral")
     {
-      command = "swift -p " + cepstral_conf + " " + data;
+      command = "aoss swift -p " + cepstral_conf + " " + data;
     }
     else
     {


### PR DESCRIPTION
Update: When using Cepstral's swift on the command line, you may encounter OSS sound compatibility errors. Install the package alsa-oss and use the program it provides 'aoss' to act as a sound wrapping layer for ALSA. For example:

```
aoss swift -f file.txt
```
