### PR TITLE
fixed cob_voltage_controls topic names

### DIFF
--- a/cob_voltage_control/common/src/cob_voltage_control_common.cpp
+++ b/cob_voltage_control/common/src/cob_voltage_control_common.cpp
@@ -28,7 +28,7 @@ public:
     int in_phidget_current;
 
     //output data
-    cob_msgs::PowerBoardState out_pub_relayboard_state;
+    cob_msgs::PowerBoardState out_pub_powerboard_state;
     cob_msgs::PowerState out_pub_powerstate_;
     cob_msgs::EmergencyStopState out_pub_em_stop_state_;
     std_msgs::Float64 out_pub_voltage;
@@ -82,9 +82,9 @@ public:
         data.out_pub_powerstate_.time_remaining = ros::Duration(1000);
         data.out_pub_powerstate_.relative_capacity = percentage;
 
-        data.out_pub_relayboard_state.header.stamp = ros::Time::now();
-        data.out_pub_relayboard_state.run_stop = false;
-        data.out_pub_relayboard_state.wireless_stop = false;
+        data.out_pub_powerboard_state.header.stamp = ros::Time::now();
+        data.out_pub_powerboard_state.run_stop = false;
+        data.out_pub_powerboard_state.wireless_stop = false;
 
     }
 

--- a/cob_voltage_control/common/src/cob_voltage_control_common.cpp
+++ b/cob_voltage_control/common/src/cob_voltage_control_common.cpp
@@ -28,9 +28,9 @@ public:
     int in_phidget_current;
 
     //output data
-    cob_msgs::PowerBoardState out_pub_em_stop_state_;
+    cob_msgs::PowerBoardState out_pub_relayboard_state;
     cob_msgs::PowerState out_pub_powerstate_;
-    cob_msgs::EmergencyStopState out_pub_relayboard_state;
+    cob_msgs::EmergencyStopState out_pub_em_stop_state_;
     std_msgs::Float64 out_pub_voltage;
     std_msgs::Float64 out_pub_current;
 };
@@ -82,9 +82,9 @@ public:
         data.out_pub_powerstate_.time_remaining = ros::Duration(1000);
         data.out_pub_powerstate_.relative_capacity = percentage;
 
-        data.out_pub_em_stop_state_.header.stamp = ros::Time::now();
-        data.out_pub_em_stop_state_.run_stop = false;
-        data.out_pub_em_stop_state_.wireless_stop = false;
+        data.out_pub_relayboard_state.header.stamp = ros::Time::now();
+        data.out_pub_relayboard_state.run_stop = false;
+        data.out_pub_relayboard_state.wireless_stop = false;
 
     }
 

--- a/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
+++ b/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
@@ -50,7 +50,7 @@ class cob_voltage_control_ros
 
         cob_voltage_control_ros()
         {
-            topicPub_powerstate = n_.advertise<cob_msgs::PowerBoardState>("relayboard_state", 1);
+            topicPub_powerstate = n_.advertise<cob_msgs::PowerBoardState>("powerboard_state", 1);
             topicPub_em_stop_state_ = n_.advertise<cob_msgs::EmergencyStopState>("em_stop_state", 1);
 
             topicPub_Current = n_.advertise<std_msgs::Float64>("current", 10);
@@ -83,7 +83,7 @@ class cob_voltage_control_ros
             component_implementation_.update(component_data_, component_config_);
             topicPub_Voltage.publish(component_data_.out_pub_voltage);
             topicPub_Current.publish(component_data_.out_pub_current);
-            topicPub_powerstate.publish(component_data_.out_pub_relayboard_state);
+            topicPub_powerstate.publish(component_data_.out_pub_powerboard_state);
             topicPub_em_stop_state_.publish(component_data_.out_pub_em_stop_state_);
         }
 

--- a/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
+++ b/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
@@ -50,14 +50,14 @@ class cob_voltage_control_ros
 
         cob_voltage_control_ros()
         {
-            topicPub_powerstate = n_.advertise<cob_msgs::PowerBoardState>("pub_em_stop_state_", 1);
-            topicPub_em_stop_state_ = n_.advertise<cob_msgs::EmergencyStopState>("pub_relayboard_state_", 1);
+            topicPub_powerstate = n_.advertise<cob_msgs::PowerBoardState>("relayboard_state", 1);
+            topicPub_em_stop_state_ = n_.advertise<cob_msgs::EmergencyStopState>("em_stop_state", 1);
 
-            topicPub_Current = n_.advertise<std_msgs::Float64>("/power_board/current", 10);
+            topicPub_Current = n_.advertise<std_msgs::Float64>("current", 10);
+            topicPub_Voltage = n_.advertise<std_msgs::Float64>("voltage", 10);
 
-            topicPub_Voltage = n_.advertise<std_msgs::Float64>("/power_board/voltage", 10);
-            topicSub_AnalogInputs = n_.subscribe("/analog_sensors", 10, &cob_voltage_control_ros::analogPhidgetSignalsCallback, this);
-            topicSub_DigitalInputs = n_.subscribe("/digital_sensors", 10, &cob_voltage_control_ros::digitalPhidgetSignalsCallback, this);
+            topicSub_AnalogInputs = n_.subscribe("input/analog_sensors", 10, &cob_voltage_control_ros::analogPhidgetSignalsCallback, this);
+            topicSub_DigitalInputs = n_.subscribe("input/digital_sensors", 10, &cob_voltage_control_ros::digitalPhidgetSignalsCallback, this);
 
             n_.param("battery_max_voltage", component_config_.max_voltage, 50.0);
             n_.param("battery_min_voltage", component_config_.min_voltage, 44.0);
@@ -70,7 +70,7 @@ class cob_voltage_control_ros
             last_front_em_state = false;
 
             EM_stop_status_ = ST_EM_ACTIVE;
-            component_data_.out_pub_relayboard_state.scanner_stop = false;
+            component_data_.out_pub_em_stop_state_.scanner_stop = false;
         }
 
         void configure()
@@ -83,8 +83,8 @@ class cob_voltage_control_ros
             component_implementation_.update(component_data_, component_config_);
             topicPub_Voltage.publish(component_data_.out_pub_voltage);
             topicPub_Current.publish(component_data_.out_pub_current);
-            topicPub_powerstate.publish(component_data_.out_pub_em_stop_state_);
-            topicPub_em_stop_state_.publish(component_data_.out_pub_relayboard_state);
+            topicPub_powerstate.publish(component_data_.out_pub_relayboard_state);
+            topicPub_em_stop_state_.publish(component_data_.out_pub_em_stop_state_);
         }
 
         void analogPhidgetSignalsCallback(const cob_phidgets::AnalogSensorConstPtr &msg)
@@ -126,27 +126,27 @@ class cob_voltage_control_ros
             {
                 if( (front_em_active && rear_em_active) && (!last_front_em_state && !last_rear_em_state))
                 {
-                    component_data_.out_pub_relayboard_state.emergency_button_stop = true;
+                    component_data_.out_pub_em_stop_state_.emergency_button_stop = true;
                     em_caused_by_button = true;
                 }
                 else if((!front_em_active && !rear_em_active) && (last_front_em_state && last_rear_em_state))
                 {
-                    component_data_.out_pub_relayboard_state.emergency_button_stop = false;
+                    component_data_.out_pub_em_stop_state_.emergency_button_stop = false;
                     em_caused_by_button = false;
                 }
                 else if((front_em_active != rear_em_active) && em_caused_by_button)
                 {
-                    component_data_.out_pub_relayboard_state.emergency_button_stop = false;
+                    component_data_.out_pub_em_stop_state_.emergency_button_stop = false;
                     em_caused_by_button = false;
-                    component_data_.out_pub_relayboard_state.scanner_stop = (bool)(front_em_active | rear_em_active);
+                    component_data_.out_pub_em_stop_state_.scanner_stop = (bool)(front_em_active | rear_em_active);
                 }
                 else
                 {
-                    component_data_.out_pub_relayboard_state.scanner_stop = (bool)(front_em_active | rear_em_active);
-                    ROS_INFO_STREAM("scanner_stop: "<<component_data_.out_pub_relayboard_state.scanner_stop);
+                    component_data_.out_pub_em_stop_state_.scanner_stop = (bool)(front_em_active | rear_em_active);
+                    ROS_INFO_STREAM("scanner_stop: "<<component_data_.out_pub_em_stop_state_.scanner_stop);
                 }
 
-                EM_signal = component_data_.out_pub_relayboard_state.scanner_stop | component_data_.out_pub_relayboard_state.emergency_button_stop;
+                EM_signal = component_data_.out_pub_em_stop_state_.scanner_stop | component_data_.out_pub_em_stop_state_.emergency_button_stop;
 
                 switch (EM_stop_status_)
                 {
@@ -185,7 +185,7 @@ class cob_voltage_control_ros
                 };
 
 
-                component_data_.out_pub_relayboard_state.emergency_state = EM_stop_status_;
+                component_data_.out_pub_em_stop_state_.emergency_state = EM_stop_status_;
 
                 last_front_em_state = front_em_active;
                 last_rear_em_state = rear_em_active;

--- a/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
+++ b/cob_voltage_control/ros/src/cob_voltage_control_ros.cpp
@@ -91,7 +91,6 @@ class cob_voltage_control_ros
         {
             for(int i = 0; i < msg->uri.size(); i++)
             {
-                std::cout << "u" << msg->uri[i] << std::endl;
                 if( msg->uri[i] == "bat1")
                 {
                     component_data_.in_phidget_voltage = msg->value[i];
@@ -143,7 +142,6 @@ class cob_voltage_control_ros
                 else
                 {
                     component_data_.out_pub_em_stop_state_.scanner_stop = (bool)(front_em_active | rear_em_active);
-                    ROS_INFO_STREAM("scanner_stop: "<<component_data_.out_pub_em_stop_state_.scanner_stop);
                 }
 
                 EM_signal = component_data_.out_pub_em_stop_state_.scanner_stop | component_data_.out_pub_em_stop_state_.emergency_button_stop;


### PR DESCRIPTION
fixes:
- renamed and remaped voltage and em state topic names
- removed console debugging output

this PR is coupled with ipa320/cob_robots#360
