### PR TITLE
Restructure relayboard nodehandles

### DIFF
--- a/cob_relayboard/ros/src/cob_relayboard_node.cpp
+++ b/cob_relayboard/ros/src/cob_relayboard_node.cpp
@@ -99,7 +99,7 @@ public:
 
     topicPub_isEmergencyStop = n.advertise<cob_msgs::EmergencyStopState>("emergency_stop_state", 1);
     topicPub_PowerBoardState = n.advertise<cob_msgs::PowerBoardState>("power_board/state", 1);
-    topicPub_Voltage = n.advertise<std_msgs::Float64>("power_board/voltage", 10);
+    topicPub_Voltage = n.advertise<std_msgs::Float64>("power_board/voltage", 1);
 
     // Make sure member variables have a defined state at the beginning
     EM_stop_status_ = ST_EM_FREE;

--- a/cob_relayboard/ros/src/cob_relayboard_node.cpp
+++ b/cob_relayboard/ros/src/cob_relayboard_node.cpp
@@ -260,40 +260,40 @@ void NodeClass::sendEmergencyStopStates()
     {
     case ST_EM_FREE:
       {
-	if (EM_signal == true)
-	  {
-	    ROS_INFO("Emergency stop was issued");
-	    EM_stop_status_ = EM_msg.EMSTOP;
-	  }
-	break;
+      if (EM_signal == true)
+        {
+          ROS_INFO("Emergency stop was issued");
+          EM_stop_status_ = EM_msg.EMSTOP;
+        }
+      break;
       }
     case ST_EM_ACTIVE:
       {
-	if (EM_signal == false)
-	  {
-	    ROS_INFO("Emergency stop was confirmed");
-	    EM_stop_status_ = EM_msg.EMCONFIRMED;
-	    time_of_EM_confirmed_ = ros::Time::now();
-	  }
-	break;
+      if (EM_signal == false)
+        {
+          ROS_INFO("Emergency stop was confirmed");
+          EM_stop_status_ = EM_msg.EMCONFIRMED;
+          time_of_EM_confirmed_ = ros::Time::now();
+        }
+      break;
       }
     case ST_EM_CONFIRMED:
       {
-	if (EM_signal == true)
-	  {
-	    ROS_INFO("Emergency stop was issued");
-	    EM_stop_status_ = EM_msg.EMSTOP;
-	  }
-	else
-	  {
-	    duration_since_EM_confirmed = ros::Time::now() - time_of_EM_confirmed_;
-	    if( duration_since_EM_confirmed.toSec() > duration_for_EM_free_.toSec() )
-	      {
-		ROS_INFO("Emergency stop released");
-		EM_stop_status_ = EM_msg.EMFREE;
-	      }
-	  }
-	break;
+      if (EM_signal == true)
+        {
+          ROS_INFO("Emergency stop was issued");
+          EM_stop_status_ = EM_msg.EMSTOP;
+        }
+      else
+        {
+          duration_since_EM_confirmed = ros::Time::now() - time_of_EM_confirmed_;
+          if( duration_since_EM_confirmed.toSec() > duration_for_EM_free_.toSec() )
+            {
+            ROS_INFO("Emergency stop released");
+            EM_stop_status_ = EM_msg.EMFREE;
+            }
+        }
+      break;
       }
     };
 

--- a/cob_relayboard/ros/src/cob_relayboard_node.cpp
+++ b/cob_relayboard/ros/src/cob_relayboard_node.cpp
@@ -82,6 +82,7 @@ class NodeClass
 public:
   // create a handle for this node, initialize node
   ros::NodeHandle n;
+  ros::NodeHandle n_priv;
 
   // topics to publish
   ros::Publisher topicPub_isEmergencyStop;
@@ -93,11 +94,12 @@ public:
   // Constructor
   NodeClass()
   {
-    n = ros::NodeHandle("~");
+    n = ros::NodeHandle();
+    n_priv = ros::NodeHandle("~");
 
-    topicPub_isEmergencyStop = n.advertise<cob_msgs::EmergencyStopState>("/emergency_stop_state", 1);
-    topicPub_PowerBoardState = n.advertise<cob_msgs::PowerBoardState>("/power_board/state", 1);
-    topicPub_Voltage = n.advertise<std_msgs::Float64>("/power_board/voltage", 10);
+    topicPub_isEmergencyStop = n.advertise<cob_msgs::EmergencyStopState>("emergency_stop_state", 1);
+    topicPub_PowerBoardState = n.advertise<cob_msgs::PowerBoardState>("power_board/state", 1);
+    topicPub_Voltage = n.advertise<std_msgs::Float64>("power_board/voltage", 10);
 
     // Make sure member variables have a defined state at the beginning
     EM_stop_status_ = ST_EM_FREE;
@@ -170,9 +172,9 @@ int main(int argc, char** argv)
 
 int NodeClass::init()
 {
-  if (n.hasParam("ComPort"))
+  if (n_priv.hasParam("ComPort"))
     {
-      n.getParam("ComPort", sComPort);
+      n_priv.getParam("ComPort", sComPort);
       ROS_INFO("Loaded ComPort parameter from parameter server: %s",sComPort.c_str());
     }
   else
@@ -181,8 +183,8 @@ int NodeClass::init()
       ROS_WARN("ComPort Parameter not available, using default Port: %s",sComPort.c_str());
     }
 
-  n.param("relayboard_timeout", relayboard_timeout_, 2.0);
-  n.param("protocol_version", protocol_version_, 1);
+  n_priv.param("relayboard_timeout", relayboard_timeout_, 2.0);
+  n_priv.param("protocol_version", protocol_version_, 1);
 
   m_SerRelayBoard = new SerRelayBoard(sComPort, protocol_version_);
   ROS_INFO("Opened Relayboard at ComPort = %s", sComPort.c_str());

--- a/cob_relayboard/ros/src/new_method.py
+++ b/cob_relayboard/ros/src/new_method.py
@@ -26,12 +26,12 @@ class volts_filter():
             self.hvalue = data
             self.volt_filt = hvalue*np.ones(2*wsize+1)
 
-	    if(data <= 44000):
-	        self.volts = 44000
+            if(data <= 44000):
+                self.volts = 44000
             time_r = 0.
             return
         elif(data >= 48000):
-	        self.volts = 48000
+                self.volts = 48000
 
         else:
             self.volts = data

--- a/cob_relayboard/ros/src/relayboard_sim.py
+++ b/cob_relayboard/ros/src/relayboard_sim.py
@@ -8,21 +8,21 @@ def relayboard_sim():
 	rospy.init_node('cob_relayboard_sim')
 
 	# emergency_stop topic
-	pub_em_stop = rospy.Publisher('/emergency_stop_state', EmergencyStopState, queue_size=1)
+	pub_em_stop = rospy.Publisher('emergency_stop_state', EmergencyStopState, queue_size=1)
 	msg_em = EmergencyStopState()
 	msg_em.emergency_button_stop = False
 	msg_em.scanner_stop = False
 	msg_em.emergency_state = 0
 
 	# power_board/state topic
-	pub_power_board = rospy.Publisher('/power_board/state', PowerBoardState, queue_size=1)
+	pub_power_board = rospy.Publisher('power_board/state', PowerBoardState, queue_size=1)
 	msg_power_board = PowerBoardState()
 	msg_power_board.header.stamp = rospy.Time.now()
 	msg_power_board.run_stop = True
 	msg_power_board.wireless_stop = True #for cob the wireless stop field is misused as laser stop field
 
 	# power_board/voltage topic
-	pub_voltage = rospy.Publisher('/power_board/voltage', Float64, queue_size=1)
+	pub_voltage = rospy.Publisher('power_board/voltage', Float64, queue_size=1)
 	msg_voltage = Float64()
 	msg_voltage.data = 48.0 # in simulation battery is always full
 


### PR DESCRIPTION
This PR remove hard-coded global namespaces within the node itself...which we always should try to avoid...It was taken from #239 separating this feature from the scan remap which is not needed anymore due to https://github.com/ipa320/cob_robots/pull/376
For our use case within [relayboard.launch](https://github.com/ipa320/cob_robots/blob/indigo_dev/cob_bringup/drivers/relayboard.launch) the topics will not change at all for our robots
