### PR TITLE
add time stamp to sick s300 diagnostic messages

### DIFF
--- a/cob_sick_s300/ros/src/cob_sick_s300.cpp
+++ b/cob_sick_s300/ros/src/cob_sick_s300.cpp
@@ -318,6 +318,7 @@ class NodeClass
 
 			//Diagnostics
 			diagnostic_msgs::DiagnosticArray diagnostics;
+			diagnostics.header.stamp = ros::Time::now();
 			diagnostics.status.resize(1);
 			diagnostics.status[0].level = 0;
 			diagnostics.status[0].name = nh.getNamespace();
@@ -327,6 +328,7 @@ class NodeClass
 
 				void publishError(std::string error_str) {
 					diagnostic_msgs::DiagnosticArray diagnostics;
+					diagnostics.header.stamp = ros::Time::now();
 					diagnostics.status.resize(1);
 					diagnostics.status[0].level = 2;
 					diagnostics.status[0].name = nh.getNamespace();
@@ -336,6 +338,7 @@ class NodeClass
 
 				void publishWarn(std::string warn_str) {
 					diagnostic_msgs::DiagnosticArray diagnostics;
+					diagnostics.header.stamp = ros::Time::now();
 					diagnostics.status.resize(1);
 					diagnostics.status[0].level = 1;
 					diagnostics.status[0].name = nh.getNamespace();


### PR DESCRIPTION
fixes the following warning on startup:

```
Node: /diagnostic_aggregator
Time: 16:14:45.321421726 (2016-02-19)
Severity: Warn
Published Topics: /diagnostics_agg, /diagnostics_toplevel_state, /rosout

No timestamp set for diagnostic message. Message names: //base_laser_left

Location:
/tmp/buildd/ros-indigo-diagnostic-aggregator-1.8.8-0trusty-20151111-0704/src/aggregator.cpp:Aggregator::checkTimestamp:88
```
