### PR TITLE
fixed static light mode

### DIFF
--- a/cob_light/common/include/mode.h
+++ b/cob_light/common/include/mode.h
@@ -66,7 +66,11 @@ public:
 	Mode(int priority = 0, double freq = 0, int pulses = 0, double timeout = 0)
 		: _priority(priority), _freq(freq), _pulses(pulses), _timeout(timeout),
 		  _finished(false), _pulsed(0), _isStopRequested(false), _isPauseRequested(false),
-		  _isRunning(false){}
+		  _isRunning(false)
+		  {
+			  if(this->getFrequency() == 0.0)
+	  		  	this->setFrequency(1.0);
+		  }
 	virtual ~Mode(){}
 
 	void start()
@@ -194,8 +198,6 @@ protected:
 	virtual void run()
 	{
 		ros::Rate r(UPDATE_RATE_HZ);
-		if(this->getFrequency() == 0.0)
-		  this->setFrequency(1);
 
 		ros::Time timeStart = ros::Time::now();
 

--- a/cob_light/common/include/staticMode.h
+++ b/cob_light/common/include/staticMode.h
@@ -69,11 +69,10 @@ public:
 
 	void execute()
 	{
+		if(_timer_inc == 0.0)
+			m_sigColorReady(_color);
 		if(_timer_inc >= 1.0)
-	    {
-	      m_sigColorReady(_color);
 	      _timer_inc = 0.0;
-	    }
 	    else
 	      _timer_inc += _inc;
 	}


### PR DESCRIPTION
static light mode with a frequency of 0.0 was not working because no internal updates were performed.
