### PR TITLE
BMS: restart CAN interface on failure

### DIFF
--- a/cob_bms_driver/src/cob_bms_driver_node.cpp
+++ b/cob_bms_driver/src/cob_bms_driver_node.cpp
@@ -460,6 +460,11 @@ void CobBmsDriverNode::diagnosticsTimerCallback(const ros::TimerEvent& event)
 {
 	//update diagnostics
 	updater_.update();
+	if(!socketcan_interface_.getState().isReady()){
+		ROS_ERROR("Restarting BMS socketcan");
+		socketcan_interface_.shutdown();
+		socketcan_interface_.recover();
+	}
 }
 
 int main(int argc, char **argv) 


### PR DESCRIPTION
Might take up to 5 seconds / errors msgs to recover
