### PR TITLE
[cob_sick_s300] fix bug reading not all scan points

### DIFF
--- a/cob_sick_s300/README.md
+++ b/cob_sick_s300/README.md
@@ -4,7 +4,7 @@ It provides an implementation for both, the old (1.40) and the new (2.10) protoc
 Thus, the old Sick S300 Professional CMS as well as the new Sick S300 Expert are supported.
 
 However, it does not cover the full functionality of the protocol:
-- It only handle distance measurements properly
+- It only handles distance measurements properly
 - It only handles no or only one configured measurement range field properly
 - It does not handle I/O-data or reflector data
 (though it reads the reflector marker field in the distance measurements)

--- a/cob_sick_s300/README.md
+++ b/cob_sick_s300/README.md
@@ -1,0 +1,22 @@
+# cob_sick_s300
+This package implements a driver for the Sick S300 Safety laser scanners.
+It provides an implementation for both, the old (1.40) and the new (2.10) protocol.
+Thus, the old Sick S300 Professional CMS as well as the new Sick S300 Expert are supported.
+
+However, it does not cover the full functionality of the protocol:
+- It only handle distance measurements properly
+- It only handles no or only one configured measurement range field properly
+- It does not handle I/O-data or reflector data
+(though it reads the reflector marker field in the distance measurements)
+
+See http://wiki.ros.org/cob_sick_s300 for more details.
+
+## S300 Configuration
+Here are a few notes about how to best configure the S300:
+- Configure the RS422 output to 500kBaud (otherwise, the scanner only provides a lower frequency)
+- Configure the scanner to Continuous Data Output
+- Send data via one telegram
+- Only configure distances, no I/O or reflector data (otherwise, the scanner only provides a lower frequency).
+- Do not configure a measurement range field (otherwise, the scanner only provides a lower frequency).
+If you want to only use certain measurement ranges, do this on the ROS side using e.g. the `cob_scan_filter`
+located in this package as well.

--- a/cob_sick_s300/README.md
+++ b/cob_sick_s300/README.md
@@ -17,6 +17,9 @@ Here are a few notes about how to best configure the S300:
 - Configure the scanner to Continuous Data Output
 - Send data via one telegram
 - Only configure distances, no I/O or reflector data (otherwise, the scanner only provides a lower frequency).
-- Do not configure a measurement range field (otherwise, the scanner only provides a lower frequency).
-If you want to only use certain measurement ranges, do this on the ROS side using e.g. the `cob_scan_filter`
+- Configuration of the measurement ranges
+    - For protocol 1.40: only configure one measurement range field with the full range (-45° to 225°) with all values.
+    - For protocol 2.10: do not configure a measurement range field
+      (otherwise, the scanner only provides a lower frequency).
+- If you want to only use certain measurement ranges, do this on the ROS side using e.g. the `cob_scan_filter`
 located in this package as well.

--- a/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
+++ b/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
@@ -156,7 +156,7 @@ public:
 	//sick_lms.Uninitialize();
 
 	// whether the scanner is currently in Standby or not
-	bool isInStandby() {return m_bInStandby;};
+	bool isInStandby() {return m_bInStandby;}
 
 	void purgeScanBuf();
 

--- a/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
+++ b/cob_sick_s300/common/include/cob_sick_s300/ScannerSickS300.h
@@ -70,37 +70,7 @@
  * Driver class for the laser scanner SICK S300 Professional.
  * This driver only supports use with 500KBaud in cont. mode
  *
- * S300 header format in continuous mode:
- *
- *      | 00 00 00 00 |   4 byte reply header
- *
- *		Now starts the actual telegram
- *
- *      | 00 00 |         data block number (fixed)
- *      | xx xx |         size of data telegram (should be dec 1104)
- *      | FF xx |         last byte decides scanner id, 07 in most cases, but 08 for slave configured scanners
- *      | xx xx |         protocol version
- *      | 0x 00 |         status: 00 00 = normal, 01 00 = lockout
- *      | xx xx xx xx |   scan number
- *      | xx xx |         telegram number
- *      | BB BB |         fixed
- *      | 11 11 |         fixed
- *	       ...            data
- *      | xx xx |         CRC
- *
- * 	   Readout of buffer starts with Reply-Header
- *	   Reply-Header:byte 0 to 3 = 4 bytes
- *	   Telegram (as it is stored in the Buffer):	Position in the telegram
- *	   Header: 		bytes 4 to 23 = 20 bytes		bytes 0 to 19
- *	   Data:   		bytes 24 to 1105 = 1082 bytes	bytes 20 to 1101
- *	   CRC:    		bytes 1106, 1107 = 2 bytes		bytes 1102, 1103
- *
- *	   for easier parsing Reply-Header and Telegram-Header are combined in the folllowing
- *	   --> Headerlength = 24 bytes (iHeaderLength)
- *	   --> Total length in buffer is 1108 bytes
- *	   --> Telegram length (read from telegram) is 1104 bytes (iDataLength)
- *
- *	   if the scanner is in standby, the measurements are 0x4004 according to the Sick Support
+ * if the scanner is in standby, the measurements are 0x4004 according to the Sick Support
  */
 
 class ScannerSickS300

--- a/cob_sick_s300/common/include/cob_sick_s300/TelegramS300.h
+++ b/cob_sick_s300/common/include/cob_sick_s300/TelegramS300.h
@@ -55,6 +55,28 @@
 
 #include <arpa/inet.h>
 
+/*
+* S300 header format in continuous mode:
+*
+*      | 00 00 00 00 |   4 byte reply header
+*      | 00 00 |         data block number (fixed for continuous output)
+*      | xx xx |         size of data telegram in 16-bit data words
+*      | FF xx |         coordination flag and device address (07 in most cases, but 08 for slave configured scanners)
+*      | xx xx |         protocol version (02 01 for old protocol,.otherwise 03 01)
+*      | 0x 00 |         status: 00 00 = normal, 01 00 = lockout
+*      | xx xx xx xx |   scan number (time stamp)
+*      | xx xx |         telegram number
+*      | BB BB |         ID of output (AAAA=I/O, BBBB=range measruements, CCCC=reflector measurements)
+*      | 11 11 |         number of configures measurement field (1111, 2222, 3333, 4444 or 5555)
+*         ...            data
+*      | xx xx |         CRC
+*
+* in this parser, user_data_ denotes all but the first 20 bytes (up to and including telegram number above)
+* and the last two bytes (CRC)
+*
+*/
+
+
 class TelegramParser {
 
 	#pragma pack(push,1)

--- a/cob_sick_s300/common/include/cob_sick_s300/TelegramS300.h
+++ b/cob_sick_s300/common/include/cob_sick_s300/TelegramS300.h
@@ -357,7 +357,7 @@ public:
 		if(!isDist()) return;
 
 		size_t num_points = (user_data_size_-sizeof(TELEGRAM_COMMON3)-sizeof(TELEGRAM_DISTANCE))/sizeof(TELEGRAM_S300_DIST_2B);
-		//if (debug) std::cout << "Number of points: " << std::dec << num_points << std::endl;
+		if (debug) std::cout << "Number of points: " << std::dec << num_points << std::endl;
 		for(size_t i=0; i<num_points; ++i) {
 			TELEGRAM_S300_DIST_2B dist = *((TELEGRAM_S300_DIST_2B*) (buffer+(sizeof(tc1_)+sizeof(tc2_)+sizeof(tc3_)+sizeof(td_)+i)) );
 			//for distance only: res.push_back((int)dist.distance);

--- a/cob_sick_s300/common/include/cob_sick_s300/TelegramS300.h
+++ b/cob_sick_s300/common/include/cob_sick_s300/TelegramS300.h
@@ -261,6 +261,7 @@ public:
 		TELEGRAM_TAIL tt;
 		uint16_t crc;
 		int full_data_size = 0;
+
 		// The size reported by the protocol varies depending on the calculation which is different depending
 		// on several factors.
 		// The calculation is described on pp. 70-73 in:
@@ -286,7 +287,7 @@ public:
 			ntoh(tt);
 			crc = createCRC((uint8_t*)buffer+JUNK_SIZE, full_data_size-JUNK_SIZE-sizeof(TELEGRAM_TAIL));
 		}
-		// Special handling for the new protocol, as this cannot be deduced from the protocol itself
+		// Special handling for the new protocol, as the settings cannot be fully deduced from the protocol itself
 		// Thus, we have to try both possibilities and check against the CRC...
 		else
 		{
@@ -322,7 +323,6 @@ public:
 			}
 		}
 
-		std::cout << std::dec << user_data_size_ << " " << full_data_size << " " << 2*tc1_.size << std::hex << std::endl;
 		if( (sizeof(TELEGRAM_COMMON1)+sizeof(TELEGRAM_COMMON2)+user_data_size_+sizeof(TELEGRAM_TAIL)) > (int)max_size)
 		{
 			if(debug) std::cout<<"invalid header size"<<std::endl;

--- a/cob_sick_s300/common/src/ScannerSickS300.cpp
+++ b/cob_sick_s300/common/src/ScannerSickS300.cpp
@@ -216,7 +216,7 @@ bool ScannerSickS300::getScan(std::vector<double> &vdDistanceM, std::vector<doub
 		// parse through the telegram until header with correct scan id is found
 		if(tp_.parseHeader(m_ReadBuf+i, m_actualBufferSize-i, m_iScanId, debug))
 		{
-			tp_.readDistRaw(m_ReadBuf+i, m_viScanRaw);
+			tp_.readDistRaw(m_ReadBuf+i, m_viScanRaw, debug);
 			if(m_viScanRaw.size()>0) {
 				// Scan was succesfully read from buffer
 				bRet = true;

--- a/cob_sick_s300/ros/src/cob_sick_s300.cpp
+++ b/cob_sick_s300/ros/src/cob_sick_s300.cpp
@@ -188,7 +188,7 @@ class NodeClass
 				}
 				else
 				{
-					ROS_WARN("No params for the Sick S300 fieldset were specified --> will using default, but it's deprecated now, please adjust parameters!!!");
+					//ROS_WARN("No params for the Sick S300 fieldset were specified --> will using default, but it's deprecated now, please adjust parameters!!!");
 
 					//setting defaults to be backwards compatible
 					ScannerSickS300::ParamType param;


### PR DESCRIPTION
This PR fixes #256 and fixes #276 by (more) correctly implementing the size calculations acoording to the (updated) Sick telegram listing.

Tested with:
- [x] S300 Pro CMS (old protocol)
- [x] S300 Expert (compatability mode)
- [x] S300 Expert (new protocol)

This PR also comments out a warning about "old" parameter sets, as those parameter sets actually are buggy --> #318

@ipa-josh 
