### PR TITLE
remove dependency to sound_play

### DIFF
--- a/cob_sound/package.xml
+++ b/cob_sound/package.xml
@@ -30,6 +30,5 @@
 
   <exec_depend>alsa-oss</exec_depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>sound_play</exec_depend>
 
 </package>


### PR DESCRIPTION
not needed and already done on kinetic_dev branch...(but it's not cherry-pick'able from there, see https://github.com/ipa320/cob_driver/commit/3205ad2f5ac253a6866eff8a688530f1482e2335)