### PR TITLE
add tinyxml to package.xml

### DIFF
--- a/cob_camera_sensors/package.xml
+++ b/cob_camera_sensors/package.xml
@@ -27,6 +27,7 @@
   <depend>polled_camera</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>tinyxml</depend>
 
   <exec_depend>rospy</exec_depend>
 


### PR DESCRIPTION
while investigating packages depending on `tinyxml` I noticed that this one didn't declare the dependency in its `package.xml` while finding it in its cmake code.
