### PR TITLE
[cob_mimic] use glx/opengl output for mimic

### DIFF
--- a/cob_mimic/src/mimic_node.cpp
+++ b/cob_mimic/src/mimic_node.cpp
@@ -79,7 +79,8 @@ public:
             "--playlist-enqueue",
             "--no-video-title-show",
             "--no-skip-frames",
-            "--no-audio"
+            "--no-audio",
+            "--vout=glx,none"
         };
         int argc = sizeof( argv ) / sizeof( *argv );
 


### PR DESCRIPTION
fixes mimic issues for 6th and 7th gen Intel Nuc's

 - fixes https://github.com/ipa320/cob_driver/issues/355
 - fixes https://github.com/ipa320/cob4/issues/555
 - fixes https://github.com/ipa320/msh/issues/845
