### PR TITLE
allow to play non-default mimics by specifying full filepath

### DIFF
--- a/cob_mimic/src/mimic_node.cpp
+++ b/cob_mimic/src/mimic_node.cpp
@@ -196,9 +196,17 @@ private:
         // check if mimic exists
         if ( !boost::filesystem::exists(filename) )
         {
-            ROS_ERROR("File not found: %s", filename.c_str());
-            mutex_.unlock();
-            return false;
+            if ( !boost::filesystem::exists(mimic) )
+            {
+                ROS_ERROR("File not found: %s", filename.c_str());
+                mutex_.unlock();
+                return false;
+            }
+            else
+            {
+                ROS_INFO("Playing mimic from non-default file: %s", mimic.c_str());
+                filename = mimic;
+            }
         }
 
         // repeat cannot be 0


### PR DESCRIPTION
this is a minimal patch that allows to play mimics (or any other *.mp4 video file) from any file location
it does not change the default behavior at all

you only need to specify the full file path in the goal/request instead of just specifying default mimics like `happy`, `sleeping` or `confused`, i.e. `/home/fxm/Videos/my_video.mp4`

@HannesBachter @ipa-bnm @ipa-fmw 
we could use this for HDG's QR visualization and/or error_mimic (as long as we do not yet reach the pop-up solution)