### PR TITLE
round remaining_capacity

### DIFF
--- a/cob_bms_driver/src/fake_bms.py
+++ b/cob_bms_driver/src/fake_bms.py
@@ -37,24 +37,24 @@ class FakeBMS(object):
         self.updater.setHardwareID("bms")
         self.updater.add("cob_bms_dagnostics_updater", self.produce_diagnostics)
 
-        self.voltage              = 0.0
+        self.voltage              = 48.0
         self.current              = -8.0
         self.remaining_capacity   = 35.0
         self.full_charge_capacity = 35.0 # Ah
-        self.temperature          = 0.0
+        self.temperature          = 25.0
 
         rospy.Timer(rospy.Duration(1.0), self.publish_diagnostics)
         rospy.Timer(rospy.Duration(1.0/self.poll_frequency), self.timer_cb)
         rospy.Timer(rospy.Duration(1.0/self.poll_frequency), self.timer_consume_power_cb)
 
     def current_cb(self, req):
-        self.current = req.data
-        res_current = SetFloatResponse(True, "Set current to {}".format(req.data))
+        self.current = round(req.data,2)
+        res_current = SetFloatResponse(True, "Set current to {}".format(self.current))
         return res_current
         
     def relative_remaining_capacity_cb(self, req):
         self.remaining_capacity = round(((req.data * self.full_charge_capacity)/100.0), 3)
-        res_capacity = SetFloatResponse(True, "Set relative remaining capacity to {}".format(req.data))
+        res_capacity = SetFloatResponse(True, "Set relative remaining capacity to {}".format(self.remaining_capacity))
         return res_capacity
 
     def publish_diagnostics(self, event):
@@ -70,20 +70,20 @@ class FakeBMS(object):
         return stat
 
     def timer_cb(self, event):
-        self.voltage = 48.0
         self.pub_voltage.publish(self.voltage)
         self.pub_current.publish(self.current)
-        self.pub_remaining_capacity.publish(round(self.remaining_capacity, 3))
+        self.pub_remaining_capacity.publish(self.remaining_capacity)
         self.pub_full_charge_capacity.publish(self.full_charge_capacity)
         self.pub_temparature.publish(self.temperature)
 
     def timer_consume_power_cb(self, event):
         # emulate the battery usage based on the current values
         self.remaining_capacity += (self.current/self.poll_frequency)/3600.0
+        self.remaining_capacity = round(self.remaining_capacity,3)
         if self.remaining_capacity <= 0.0:
             self.remaining_capacity = 0.0
         if self.remaining_capacity >= self.full_charge_capacity:
-            self.remaining_capacity = self.full_charge_capacity
+            self.remaining_capacity = round(self.full_charge_capacity,3)
         
 if __name__ == '__main__':
   rospy.init_node('fake_bms')

--- a/cob_bms_driver/src/fake_bms.py
+++ b/cob_bms_driver/src/fake_bms.py
@@ -73,7 +73,7 @@ class FakeBMS(object):
         self.voltage = 48.0
         self.pub_voltage.publish(self.voltage)
         self.pub_current.publish(self.current)
-        self.pub_remaining_capacity.publish(self.remaining_capacity)
+        self.pub_remaining_capacity.publish(round(self.remaining_capacity, 3))
         self.pub_full_charge_capacity.publish(self.full_charge_capacity)
         self.pub_temparature.publish(self.temperature)
 


### PR DESCRIPTION
round the remaining_capacity from the bms fake node to 3 digits (same way as it is done by the real bms driver)