### PR TITLE
include boost/format.hpp

### DIFF
--- a/cob_bms_driver/src/cob_bms_driver_node.cpp
+++ b/cob_bms_driver/src/cob_bms_driver_node.cpp
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 #include <endian.h>
+#include <boost/format.hpp>
 
 #include <cob_bms_driver/cob_bms_driver_node.h>
 


### PR DESCRIPTION
 - fixes compilation with newer boost (I have 1.65 installed but I think this is an issue since at least 1.62)