### PR TITLE
fix install tags

### DIFF
--- a/cob_sound/CMakeLists.txt
+++ b/cob_sound/CMakeLists.txt
@@ -32,6 +32,6 @@ install(TARGETS sound
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(PROGRAMS ros/src/test_client.py
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}/ros/src
+install(PROGRAMS ros/src/test_client.py fix_swift_for_precise.sh
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
the file is required during http://wiki.ros.org/cob_sound#Installing_cepstral_vices_and_license, thus it should be installed