### PR TITLE
add laser scan densifier

### DIFF
--- a/laser_scan_densifier/CMakeLists.txt
+++ b/laser_scan_densifier/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(laser_scan_densifier)
+
+# List C++ dependencies on ros packages
+set( ROS_CXX_DEPENDENCIES
+  roscpp
+  nodelet
+  sensor_msgs)
+
+# Find catkin and all required ROS components
+find_package(catkin REQUIRED COMPONENTS ${ROS_CXX_DEPENDENCIES})
+
+# Set include directories
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+# Declare info that other packages need to import library generated here
+catkin_package(
+    INCLUDE_DIRS include
+    LIBRARIES laser_scan_densifier
+    CATKIN_DEPENDS ${ROS_CXX_DEPENDENCIES}
+)
+
+#Create library
+add_library(laser_scan_densifier src/laser_scan_densifier.cpp)
+target_link_libraries( laser_scan_densifier ${catkin_LIBRARIES})
+add_dependencies(laser_scan_densifier ${catkin_EXPORTED_TARGETS})
+
+#Create nodelet
+add_library(laser_scan_densifier_nodelet src/laser_scan_densifier_nodelet.cpp)
+target_link_libraries(laser_scan_densifier_nodelet laser_scan_densifier)
+
+#Create node
+add_executable(laser_scan_densifier_node src/laser_scan_densifier_node.cpp)
+target_link_libraries( laser_scan_densifier_node laser_scan_densifier )
+
+#Install library
+install(TARGETS laser_scan_densifier laser_scan_densifier_nodelet
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+
+#Install library includes
+install(DIRECTORY include/laser_scan_densifier/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION} )
+
+#Install node
+install(TARGETS laser_scan_densifier_node
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION} )
+
+#Install nodelet description
+install(FILES laser_scan_densifier_nodelet.xml
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} )

--- a/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier.h
+++ b/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier.h
@@ -68,6 +68,7 @@ class LaserScanDensifier
     // **** paramaters
 
     int step_;
+    int mode_;
 
     // **** member functions
 

--- a/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier.h
+++ b/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (c) 2011, Ivan Dryanovski
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the CCNY Robotics Lab nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LASER_SCAN_DENSIFIER_LASER_SCAN_DENSIFIER_H
+#define LASER_SCAN_DENSIFIER_LASER_SCAN_DENSIFIER_H
+
+#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+
+namespace scan_tools {
+
+class LaserScanDensifier
+{
+  public:
+
+    LaserScanDensifier(ros::NodeHandle nh, ros::NodeHandle nh_private);
+    virtual ~LaserScanDensifier();
+
+  private:
+
+    // **** ROS-related
+    ros::NodeHandle nh_;
+    ros::NodeHandle nh_private_;
+    ros::Subscriber scan_subscriber_;
+    ros::Publisher  scan_publisher_;
+
+    // **** paramaters
+
+    int step_;
+
+    // **** member functions
+
+    void scanCallback(const sensor_msgs::LaserScanConstPtr& scan_msg);
+};
+
+} //namespace scan_tools
+
+#endif // LASER_SCAN_DENSIFIER_LASER_SCAN_DENSIFIER_H

--- a/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier_nodelet.h
+++ b/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier_nodelet.h
@@ -58,7 +58,7 @@ class LaserScanDensifierNodelet : public nodelet::Nodelet
     virtual void onInit();
 
   private:
-    LaserScanDensifier * laser_scan_densifier_;  // FIXME: change to smart pointer
+    boost::shared_ptr< LaserScanDensifier > laser_scan_densifier_;
 };
 
 } //namespace scan_tools

--- a/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier_nodelet.h
+++ b/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier_nodelet.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (c) 2011, Ivan Dryanovski
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the CCNY Robotics Lab nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LASER_SCAN_DENSIFIER_LASER_SCAN_DENSIFIER_NODELET_H
+#define LASER_SCAN_DENSIFIER_LASER_SCAN_DENSIFIER_NODELET_H
+
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
+
+#include "laser_scan_densifier/laser_scan_densifier.h"
+
+namespace scan_tools {
+
+class LaserScanDensifierNodelet : public nodelet::Nodelet
+{
+  public:
+    virtual void onInit();
+
+  private:
+    LaserScanDensifier * laser_scan_densifier_;  // FIXME: change to smart pointer
+};
+
+} //namespace scan_tools
+
+#endif // LASER_SCAN_DENSIFIER_LASER_SCAN_DENSIFIER_NODELET_H

--- a/laser_scan_densifier/laser_scan_densifier_nodelet.xml
+++ b/laser_scan_densifier/laser_scan_densifier_nodelet.xml
@@ -1,0 +1,9 @@
+<!-- Laser scan densifier nodelet publisher -->
+<library path="lib/liblaser_scan_densifier_nodelet">
+  <class name="laser_scan_densifier/LaserScanDensifierNodelet" type="LaserScanDensifierNodelet" 
+    base_class_type="nodelet::Nodelet">
+    <description>
+      Laser scan densifier nodelet publisher.
+    </description>
+  </class>
+</library>

--- a/laser_scan_densifier/package.xml
+++ b/laser_scan_densifier/package.xml
@@ -1,0 +1,23 @@
+<package format="2">
+  <name>laser_scan_densifier</name>
+  <version>0.6.12</version>
+  <description>
+    The laser_scan_densifier takes in a LaserScan message and densifies it.
+    Node is inspired by laser_scan_sparsifier (http://wiki.ros.org/laser_scan_sparsifier).
+  </description>
+  <maintainer email="felixmessmer@gmail.com">Felix Messmer</maintainer>
+  <author email="felixmessmer@gmail.com">Felix Messmer</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>roscpp</depend>
+  <depend>nodelet</depend>
+  <depend>sensor_msgs</depend>
+
+  <export>
+    <nodelet plugin="${prefix}/laser_scan_densifier_nodelet.xml" />
+  </export>
+
+</package>

--- a/laser_scan_densifier/src/laser_scan_densifier.cpp
+++ b/laser_scan_densifier/src/laser_scan_densifier.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (c) 2011, Ivan Dryanovski, William Morris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the CCNY Robotics Lab nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "laser_scan_densifier/laser_scan_densifier.h"
+
+namespace scan_tools {
+
+LaserScanDensifier::LaserScanDensifier(ros::NodeHandle nh, ros::NodeHandle nh_private):
+  nh_(nh), 
+  nh_private_(nh_private)
+{
+  ROS_INFO ("Starting LaserScanDensifier");
+
+  // **** get paramters
+
+  if (!nh_private_.getParam ("step", step_))
+    step_ = 2;
+
+  ROS_ASSERT_MSG(step_ > 0, "step parameter is set to %, must be > 0", step_);
+
+  // **** advertise topics
+
+  scan_publisher_ = nh_.advertise<sensor_msgs::LaserScan>("scan_dense", 1);
+
+  // **** subscribe to laser scan messages
+
+  scan_subscriber_ = nh_.subscribe("scan", 1, &LaserScanDensifier::scanCallback, this);
+}
+
+LaserScanDensifier::~LaserScanDensifier ()
+{
+  ROS_INFO ("Destroying LaserScanDensifier");
+}
+
+void LaserScanDensifier::scanCallback (const sensor_msgs::LaserScanConstPtr& scan_msg)
+{
+  sensor_msgs::LaserScan::Ptr scan_dense;
+  scan_dense = boost::make_shared<sensor_msgs::LaserScan>();
+
+  // copy over equal fields
+
+  scan_dense->header          = scan_msg->header;
+  scan_dense->range_min       = scan_msg->range_min;
+  scan_dense->range_max       = scan_msg->range_max;
+  scan_dense->angle_min       = scan_msg->angle_min;
+  scan_dense->angle_max       = scan_msg->angle_max;
+  scan_dense->angle_increment = scan_msg->angle_increment / step_;
+  scan_dense->time_increment  = scan_msg->time_increment;
+  scan_dense->scan_time       = scan_msg->scan_time;
+
+  scan_dense->ranges.clear();
+  scan_dense->intensities.clear();
+
+  for (unsigned int i = 0; i < scan_msg->ranges.size()-1; i++)
+  {
+    scan_dense->ranges.insert(scan_dense->ranges.end(), step_, scan_msg->ranges[i]);
+    scan_dense->intensities.insert(scan_dense->intensities.end(), step_, scan_msg->intensities[i]);
+  }
+  scan_dense->ranges.push_back(scan_msg->ranges.back());
+  scan_dense->intensities.push_back(scan_msg->intensities.back());
+
+  scan_publisher_.publish(scan_dense);
+}
+
+} //namespace scan_tools
+

--- a/laser_scan_densifier/src/laser_scan_densifier.cpp
+++ b/laser_scan_densifier/src/laser_scan_densifier.cpp
@@ -95,6 +95,9 @@ void LaserScanDensifier::scanCallback (const sensor_msgs::LaserScanConstPtr& sca
   for (unsigned int i = 0; i < scan_msg->ranges.size()-1; i++)
   {
     scan_dense->ranges.insert(scan_dense->ranges.end(), step_, scan_msg->ranges[i]);
+    //double delta = (scan_msg->ranges[i+1]-scan_msg->ranges[i])/step_;
+    //for (unsigned int k = 0; k < step_; k++)
+    //    scan_dense->ranges.insert(scan_dense->ranges.end(), 1, scan_msg->ranges[i]+k*delta);
     scan_dense->intensities.insert(scan_dense->intensities.end(), step_, scan_msg->intensities[i]);
   }
   scan_dense->ranges.push_back(scan_msg->ranges.back());

--- a/laser_scan_densifier/src/laser_scan_densifier_node.cpp
+++ b/laser_scan_densifier/src/laser_scan_densifier_node.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (c) 2011, Ivan Dryanovski, William Morris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the CCNY Robotics Lab nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "laser_scan_densifier/laser_scan_densifier.h"
+
+int main (int argc, char **argv)
+{
+  ros::init (argc, argv, "LaserScanDensifier");
+  ros::NodeHandle nh;
+  ros::NodeHandle nh_private("~");
+  scan_tools::LaserScanDensifier laser_scan_densifier(nh, nh_private);
+  ros::spin ();
+  return 0;
+}

--- a/laser_scan_densifier/src/laser_scan_densifier_nodelet.cpp
+++ b/laser_scan_densifier/src/laser_scan_densifier_nodelet.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright (c) 2011, Ivan Dryanovski, William Morris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the CCNY Robotics Lab nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "laser_scan_densifier/laser_scan_densifier_nodelet.h"
+
+typedef scan_tools::LaserScanDensifierNodelet LaserScanDensifierNodelet;
+
+PLUGINLIB_EXPORT_CLASS(LaserScanDensifierNodelet, nodelet::Nodelet)
+
+void LaserScanDensifierNodelet::onInit ()
+{
+  NODELET_INFO("Initializing LaserScanDensifier Nodelet");
+  
+  // TODO: Do we want the single threaded or multithreaded NH?
+  ros::NodeHandle nh         = getMTNodeHandle();
+  ros::NodeHandle nh_private = getMTPrivateNodeHandle();
+
+  laser_scan_densifier_ = new LaserScanDensifier(nh, nh_private);  
+}

--- a/laser_scan_densifier/src/laser_scan_densifier_nodelet.cpp
+++ b/laser_scan_densifier/src/laser_scan_densifier_nodelet.cpp
@@ -56,5 +56,5 @@ void LaserScanDensifierNodelet::onInit ()
   ros::NodeHandle nh         = getMTNodeHandle();
   ros::NodeHandle nh_private = getMTPrivateNodeHandle();
 
-  laser_scan_densifier_ = new LaserScanDensifier(nh, nh_private);  
+  laser_scan_densifier_ = boost::shared_ptr< LaserScanDensifier >(new LaserScanDensifier(nh, nh_private));
 }


### PR DESCRIPTION
a node adding additional sensor points to a LaserScan topic...

interpolating between two data points does not really work using `/scan_unified` as input as this node overwrites some ranges with plain 0...resulting in long fake points along a virtual ray

inserting data points works looks better:
![screenshot from 2018-09-12 17-48-33](https://user-images.githubusercontent.com/508006/45437013-5d456e80-b6b4-11e8-887f-ebff3a200c66.png)
