### PR TITLE
initialize ranges with max_range rather than zero

### DIFF
--- a/cob_scan_unifier/src/scan_unifier_node.cpp
+++ b/cob_scan_unifier/src/scan_unifier_node.cpp
@@ -235,8 +235,8 @@ bool ScanUnifierNode::unifyLaserScans(std::vector<sensor_msgs::LaserScan::ConstP
     unified_scan.scan_time = current_scans.at(0)->scan_time;
     unified_scan.range_min = current_scans.at(0)->range_min;
     unified_scan.range_max = current_scans.at(0)->range_max;
-    unified_scan.ranges.resize(round((unified_scan.angle_max - unified_scan.angle_min) / unified_scan.angle_increment) + 1);
-    unified_scan.intensities.resize(round((unified_scan.angle_max - unified_scan.angle_min) / unified_scan.angle_increment) + 1);
+    unified_scan.ranges.resize(round((unified_scan.angle_max - unified_scan.angle_min) / unified_scan.angle_increment) + 1, unified_scan.range_max);
+    unified_scan.intensities.resize(round((unified_scan.angle_max - unified_scan.angle_min) / unified_scan.angle_increment) + 1, 0.0);
 
     // now unify all Scans
     ROS_DEBUG("unify scans");
@@ -264,7 +264,7 @@ bool ScanUnifierNode::unifyLaserScans(std::vector<sensor_msgs::LaserScan::ConstP
 
         double range_sq = y*y+x*x;
         //printf ("index xyz( %f %f %f) angle %f index %d range %f\n", x, y, z, angle, index, sqrt(range_sq));
-        if( (unified_scan.ranges.at(index) == 0) || (sqrt(range_sq) <= unified_scan.ranges.at(index)) )
+        if( (sqrt(range_sq) <= unified_scan.ranges.at(index)) )
         {
           // use the nearest reflection point of all scans for unified scan
           unified_scan.ranges.at(index) = sqrt(range_sq);

--- a/cob_scan_unifier/src/scan_unifier_node.cpp
+++ b/cob_scan_unifier/src/scan_unifier_node.cpp
@@ -235,6 +235,9 @@ bool ScanUnifierNode::unifyLaserScans(std::vector<sensor_msgs::LaserScan::ConstP
     unified_scan.scan_time = current_scans.at(0)->scan_time;
     unified_scan.range_min = current_scans.at(0)->range_min;
     unified_scan.range_max = current_scans.at(0)->range_max;
+    //default values (ranges: range_max, intensities: 0) are used to better reflect the driver behavior
+    //there "phantom" data has values > range_max
+    //but those values are removed during projection to pointcloud
     unified_scan.ranges.resize(round((unified_scan.angle_max - unified_scan.angle_min) / unified_scan.angle_increment) + 1, unified_scan.range_max);
     unified_scan.intensities.resize(round((unified_scan.angle_max - unified_scan.angle_min) / unified_scan.angle_increment) + 1, 0.0);
 


### PR DESCRIPTION
situation before:
 - `cob_sick_s300` driver publishes some ranges as `29.959999084472656` - most likely due to reflections e.g. from railings or glass fronts
 - these data points are removed during the projection in `cob_scan_unifer` - because they are `>max_range` (max_range=29.5)
 - the `unified_scan.ranges` are initialized with `0.0`
 - for those data points removed during projection, `scan_unified` will have a range of `0.0` which later gets removed during `laser_zone_filter` resulting in "holes" in the scan
 - along the rays within those "holes" the costmap cannot clear the obstacle layer

situation now:
 - now scan_unifier behaves as the driver: fake data points are set to `max_range`

this significantly reduces "trails" in the costmap for the scan unified obstacle layer

I already verified the behavior on `cob4-22` in 25h köln....and it looks much better

contributes to https://github.com/mojin-robotics/cob4/issues/888#issuecomment-439805060