### PR TITLE
add int bms parameter types

### DIFF
--- a/cob_bms_driver/CMakeLists.txt
+++ b/cob_bms_driver/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_bms_driver)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   diagnostic_msgs
   diagnostic_updater

--- a/cob_bms_driver/CMakeLists.txt
+++ b/cob_bms_driver/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_bms_driver)
 
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED COMPONENTS
   diagnostic_msgs
   diagnostic_updater

--- a/cob_bms_driver/src/cob_bms_driver_node.cpp
+++ b/cob_bms_driver/src/cob_bms_driver_node.cpp
@@ -21,7 +21,6 @@
 #include <std_msgs/Bool.h>
 #include <XmlRpcException.h>
 
-#include <string>
 #include <stdint.h>
 #include <endian.h>
 #include <boost/format.hpp>
@@ -97,7 +96,7 @@ struct IntBmsParameter : TypedBmsParameter<std_msgs::Int64> {
     void update(const can::Frame &f){
         readTypedValue(f, *this, msg_.data);
 
-        kv.value = std::to_string(msg_.data);
+        kv.value = (boost::format("%lld") % msg_.data).str();
         publish();
     }
 };
@@ -107,7 +106,7 @@ struct UIntBmsParameter : TypedBmsParameter<std_msgs::UInt64> {
     void update(const can::Frame &f){
         readTypedValue(f, *this, msg_.data);
 
-        kv.value = std::to_string(msg_.data);
+        kv.value = (boost::format("%llu") % msg_.data).str();
         publish();
     }
 };


### PR DESCRIPTION
the BMS CAN protocol contains a few variables that are neither Float nor Bool, so adding Int/UInt seems helpfull....

currently testing an extended config on our robots - with more/full diagnostic infos...