### PR TITLE
[mimic] feature/reduce load - compress videos

### DIFF
--- a/cob_mimic/CMakeLists.txt
+++ b/cob_mimic/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_mimic)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
-find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs message_generation roscpp roslib swri_profiler)
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs message_generation roscpp roslib)
 find_package(PkgConfig REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread)
 pkg_check_modules(libvlc REQUIRED libvlc)

--- a/cob_mimic/CMakeLists.txt
+++ b/cob_mimic/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_mimic)
 
-find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs message_generation roscpp roslib)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs message_generation roscpp roslib swri_profiler)
 find_package(PkgConfig REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem thread)
 pkg_check_modules(libvlc REQUIRED libvlc)

--- a/cob_mimic/package.xml
+++ b/cob_mimic/package.xml
@@ -25,6 +25,7 @@
   <depend>libvlc-dev</depend>
   <depend>roscpp</depend>
   <depend>roslib</depend>
+  <depend>swri_profiler</depend>
   <depend>vlc</depend>
 
 </package>

--- a/cob_mimic/package.xml
+++ b/cob_mimic/package.xml
@@ -27,5 +27,6 @@
   <depend>roslib</depend>
   <depend>swri_profiler</depend>
   <depend>vlc</depend>
+  <depend>ffmpeg</depend>
 
 </package>

--- a/cob_mimic/package.xml
+++ b/cob_mimic/package.xml
@@ -25,7 +25,6 @@
   <depend>libvlc-dev</depend>
   <depend>roscpp</depend>
   <depend>roslib</depend>
-  <depend>swri_profiler</depend>
   <depend>vlc</depend>
   <depend>ffmpeg</depend>
 

--- a/cob_mimic/src/mimic_node.cpp
+++ b/cob_mimic/src/mimic_node.cpp
@@ -185,8 +185,14 @@ private:
             if(p.extension().string().compare(".mp4") == 0)
             {
                 // Convert to qtrle-encoded file
+                // -y : do not ask for permission to overwrite file
+                // -loglevel warning : Only log warnings
+                // -i : specify input file
+                // -c:v qtrel: convert the *v*ideo stream qith qtrle encoding
+                // rest is output file specification, so the output file has qtrle encoding/
+                // qtrle: https://wiki.multimedia.cx/index.php/Apple_QuickTime_RLE
                 std::stringstream command;
-                command << "ffmpeg -y -i " << p.string() << " -c:v qtrle " << p.parent_path().string()  << "/" << p.stem().string() << "_qtrle.mov";
+                command << "ffmpeg -y -loglevel warning -i " << p.string() << " -c:v qtrle " << p.parent_path().string()  << "/" << p.stem().string() << "_qtrle.mov";
                 if(background)
                 {
                     command << " &";

--- a/cob_mimic/src/mimic_node.cpp
+++ b/cob_mimic/src/mimic_node.cpp
@@ -220,7 +220,9 @@ private:
         new_mimic_request_=false;
         ROS_INFO("Mimic: %s (speed: %f, repeat: %d)", mimic.c_str(), speed, repeat);
 
-        std::string filename = mimic_folder_ + "/" + mimic + ".mp4";
+//        std::string filename = mimic_folder_ + "/" + mimic + ".mp4";
+        std::string filename = "/tmp/mimic_mov/" + mimic + "_qtrle.mov";
+
 
         // check if mimic exists
         if ( !boost::filesystem::exists(filename) )

--- a/cob_mimic/src/mimic_node.cpp
+++ b/cob_mimic/src/mimic_node.cpp
@@ -37,8 +37,6 @@
 #include <boost/random/uniform_real_distribution.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 
-#include <swri_profiler/profiler.h>
-
 class Mimic
 {
 public:
@@ -58,7 +56,6 @@ public:
 
     bool init()
     {
-        SWRI_PROFILE("init");
         if(!copy_mimic_files())
             return false;
 
@@ -148,7 +145,6 @@ private:
 
     bool copy_mimic_files()
     {
-        SWRI_PROFILE("copy_mimic_files");
         char *lgn;
         if((lgn = getlogin()) == NULL)
         {
@@ -233,7 +229,6 @@ private:
 
     void as_cb_mimic_(const cob_mimic::SetMimicGoalConstPtr &goal)
     {
-        SWRI_PROFILE("as_cb_mimic_");
         blinking_timer_.stop();
         action_active_ = true;
 
@@ -250,8 +245,6 @@ private:
     bool service_cb_mimic(cob_mimic::SetMimic::Request &req,
                           cob_mimic::SetMimic::Response &res )
     {
-        SWRI_PROFILE("service_cb_mimic");
-
         service_active_ = true;
         blinking_timer_.stop();
 
@@ -266,9 +259,6 @@ private:
 
     bool set_mimic(std::string mimic, int repeat, float speed, bool blocking=true)
     {
-        SWRI_PROFILE("set_mimic");
-
-        bool ret = false;
         new_mimic_request_=true;
         ROS_INFO("New mimic request with: %s", mimic.c_str());
         mutex_.lock();
@@ -328,11 +318,8 @@ private:
         // returns -1 if an error was detected, 0 otherwise (but even then, it might not actually work depending on the underlying media protocol)
         if(libvlc_media_player_set_rate(vlc_player_, speed)!=0){ROS_ERROR("failed to set movie play rate");}
 
-        ros::Duration dur(0.1);
-
         while(repeat > 0)
         {
-            SWRI_PROFILE("service_cb_mimic-repeat");
             vlc_media_ = libvlc_media_new_path(vlc_inst_, filename.c_str());
             if(!vlc_media_)
             {
@@ -354,11 +341,10 @@ private:
                 return false;
             }
 
-            dur.sleep();
+            ros::Duration(0.1).sleep();
             while(blocking && (libvlc_media_player_is_playing(vlc_player_) == 1))
             {
-                SWRI_PROFILE("service_cb_mimic-block_while_vlc_is_playing");
-                dur.sleep();
+                ros::Duration(0.1).sleep();
                 ROS_DEBUG("still playing %s", mimic.c_str());
                 if(new_mimic_request_)
                 {
@@ -377,7 +363,6 @@ private:
 
     void blinking_cb(const ros::TimerEvent&)
     {
-        SWRI_PROFILE("blinking_cb");
         int rand = int_dist_(gen_);
         set_mimic(random_mimics_[rand], 1, 1.5);
         blinking_timer_ = nh_.createTimer(ros::Duration(real_dist_(gen_)), &Mimic::blinking_cb, this, true);
@@ -386,7 +371,6 @@ private:
     bool copy_dir( boost::filesystem::path const & source,
             boost::filesystem::path const & mimic_folder )
     {
-        SWRI_PROFILE("copy_dir");
         namespace fs = boost::filesystem;
         try
         {

--- a/cob_mimic/src/mimic_node.cpp
+++ b/cob_mimic/src/mimic_node.cpp
@@ -178,27 +178,33 @@ private:
         }
     }
 
+    bool convert_mediafile(boost::filesystem::path const &p)
+    {
+        if(boost::filesystem::is_regular_file(p))
+        {
+            if(p.extension().string().compare(".mp4") == 0)
+            {
+                // Convert to qtrle-encoded file
+                std::stringstream command;
+                command << "ffmpeg -y -i " << p.string() << " -c:v qtrle " << p.parent_path().string()  << "/" << p.stem().string() << "_qtrle.mov";
+                ROS_INFO("Converting using command `%s`", command.str().c_str());
+                return system(command.str().c_str()) == 0;
+            }
+            else
+            {
+                ROS_INFO("Skipping conversion of %s", p.string().c_str());
+                return true;
+            }
+        }
+    }
+
     bool convert_mimic_files()
     {
         boost::filesystem::directory_iterator it(mimic_folder_), eod;
 
         BOOST_FOREACH(boost::filesystem::path const &p, std::make_pair(it, eod))
         {
-            if(boost::filesystem::is_regular_file(p))
-            {
-                if(p.extension().string().compare(".mp4") == 0)
-                {
-                    // Convert to qtrle-encoded file
-                    std::stringstream command;
-                    command << "ffmpeg -y -i " << p.string() << " -c:v qtrle " << p.parent_path().string()  << "/" << p.stem().string() << "_qtrle.mov";
-                    ROS_INFO("Converting using command `%s`", command.str().c_str());
-                    system(command.str().c_str());
-                }
-                else
-                {
-                    ROS_INFO("Skipping conversion of %s", p.string());
-                }
-            }
+            convert_mediafile(p);
         }
         return true;
     }


### PR DESCRIPTION
 - fixes https://github.com/mojin-robotics/cob4/issues/1193

Decoding highly compressed .mp4 files requires a lot of CPU. This PR introduces a parameter that will decompress the files either at init or during a mimic. 
The latter option will make that a *next* use of that mimic is faster. 