### PR TITLE
fix format specifiers

### DIFF
--- a/laser_scan_densifier/src/laser_scan_densifier.cpp
+++ b/laser_scan_densifier/src/laser_scan_densifier.cpp
@@ -57,7 +57,7 @@ LaserScanDensifier::LaserScanDensifier(ros::NodeHandle nh, ros::NodeHandle nh_pr
   nh_private_.param("step", step_, 2);
   nh_private_.param("mode", mode_, 0);
 
-  ROS_ASSERT_MSG(step_ > 0, "step parameter is set to %, must be > 0", step_);
+  ROS_ASSERT_MSG(step_ > 0, "step parameter is set to %d, must be > 0", step_);
 
   switch(mode_) {
     case 0: ROS_INFO("LaserScanDensifier started with mode %d: copy data points", mode_);

--- a/laser_scan_densifier/src/laser_scan_densifier.cpp
+++ b/laser_scan_densifier/src/laser_scan_densifier.cpp
@@ -57,7 +57,11 @@ LaserScanDensifier::LaserScanDensifier(ros::NodeHandle nh, ros::NodeHandle nh_pr
   nh_private_.param("step", step_, 2);
   nh_private_.param("mode", mode_, 0);
 
-  ROS_ASSERT_MSG(step_ > 0, "step parameter is set to %d, must be > 0", step_);
+  if (step_ <= 0)
+  {
+    ROS_ERROR("LaserScanDensifier has step parameter set to %d, must be > 0! Not initiating subscriptions...", step_);
+    exit(-1);
+  }
 
   switch(mode_) {
     case 0: ROS_INFO("LaserScanDensifier started with mode %d: copy data points", mode_);


### PR DESCRIPTION
as found by travis/`catkin build`

```
Warnings   << laser_scan_densifier:make /root/target_ws/logs/laser_scan_densifier/build.make.000.log
In file included from /opt/ros/kinetic/include/ros/ros.h:40:0,
                 from /root/target_ws/src/cob_driver/laser_scan_densifier/include/laser_scan_densifier/laser_scan_densifier.h:48,
                 from /root/target_ws/src/cob_driver/laser_scan_densifier/src/laser_scan_densifier.cpp:45:
/root/target_ws/src/cob_driver/laser_scan_densifier/src/laser_scan_densifier.cpp: In constructor ‘scan_tools::LaserScanDensifier::LaserScanDensifier(ros::NodeHandle, ros::NodeHandle)’:
/opt/ros/kinetic/include/ros/console.h:346:176: warning: unknown conversion type character ‘,’ in format [-Wformat=]
     ::ros::console::print(filter, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, __FILE__, __LINE__, __ROSCONSOLE_FUNCTION__, __VA_ARGS__)
                                                                                                                                                                                ^
/opt/ros/kinetic/include/ros/console.h:349:5: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER’
     ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER(0, __VA_ARGS__)
     ^
/opt/ros/kinetic/include/ros/console.h:379:7: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION’
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
       ^
/opt/ros/kinetic/include/ros/console.h:561:35: note: in expansion of macro ‘ROS_LOG_COND’
 #define ROS_LOG(level, name, ...) ROS_LOG_COND(true, level, name, __VA_ARGS__)
                                   ^
/opt/ros/kinetic/include/rosconsole/macros_generated.h:266:24: note: in expansion of macro ‘ROS_LOG’
 #define ROS_FATAL(...) ROS_LOG(::ros::console::levels::Fatal, ROSCONSOLE_DEFAULT_NAME, __VA_ARGS__)
                        ^
/opt/ros/kinetic/include/ros/assert.h:134:7: note: in expansion of macro ‘ROS_FATAL’
       ROS_FATAL(__VA_ARGS__); \
       ^
/root/target_ws/src/cob_driver/laser_scan_densifier/src/laser_scan_densifier.cpp:60:3: note: in expansion of macro ‘ROS_ASSERT_MSG’
   ROS_ASSERT_MSG(step_ > 0, "step parameter is set to %, must be > 0", step_);
   ^
/opt/ros/kinetic/include/ros/console.h:346:176: warning: too many arguments for format [-Wformat-extra-args]
     ::ros::console::print(filter, __rosconsole_define_location__loc.logger_, __rosconsole_define_location__loc.level_, __FILE__, __LINE__, __ROSCONSOLE_FUNCTION__, __VA_ARGS__)
                                                                                                                                                                                ^
/opt/ros/kinetic/include/ros/console.h:349:5: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER’
     ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER(0, __VA_ARGS__)
     ^
/opt/ros/kinetic/include/ros/console.h:379:7: note: in expansion of macro ‘ROSCONSOLE_PRINT_AT_LOCATION’
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
       ^
/opt/ros/kinetic/include/ros/console.h:561:35: note: in expansion of macro ‘ROS_LOG_COND’
 #define ROS_LOG(level, name, ...) ROS_LOG_COND(true, level, name, __VA_ARGS__)
                                   ^
/opt/ros/kinetic/include/rosconsole/macros_generated.h:266:24: note: in expansion of macro ‘ROS_LOG’
 #define ROS_FATAL(...) ROS_LOG(::ros::console::levels::Fatal, ROSCONSOLE_DEFAULT_NAME, __VA_ARGS__)
                        ^
/opt/ros/kinetic/include/ros/assert.h:134:7: note: in expansion of macro ‘ROS_FATAL’
       ROS_FATAL(__VA_ARGS__); \
       ^
/root/target_ws/src/cob_driver/laser_scan_densifier/src/laser_scan_densifier.cpp:60:3: note: in expansion of macro ‘ROS_ASSERT_MSG’
   ROS_ASSERT_MSG(step_ > 0, "step parameter is set to %, must be > 0", step_);
   ^
cd /root/target_ws/build/laser_scan_densifier; catkin build --get-env laser_scan_densifier | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
```