### PR TITLE
[cob_light] removed unused Boost signals dependency

### DIFF
--- a/cob_light/CMakeLists.txt
+++ b/cob_light/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS actionlib_msgs actionlib diagnostic_msgs message_generation roscpp sensor_msgs std_msgs visualization_msgs)
 
-find_package(Boost REQUIRED COMPONENTS signals thread)
+find_package(Boost REQUIRED COMPONENTS thread)
 
 ### Message Generation ###
 add_message_files(


### PR DESCRIPTION
`cob_light` depends on Boost signals2, which is a header only library that does not need to be found using `find_package`. The `CMakeLists.txt` tries to find Boost signals (v1). This library was removed in Boost 1.69, causing this package to fail to build.