### PR TITLE
Remove leading slashes from frame ids

### DIFF
--- a/cob_sick_s300/ros/src/cob_sick_s300.cpp
+++ b/cob_sick_s300/ros/src/cob_sick_s300.cpp
@@ -98,7 +98,7 @@ class NodeClass
 			nh.param("inverted", inverted, false);
 
 			if(!nh.hasParam("frame_id")) ROS_WARN("Used default parameter for frame_id");
-			nh.param("frame_id", frame_id, std::string("/base_laser_link"));
+			nh.param("frame_id", frame_id, std::string("base_laser_link"));
 
 			if(!nh.hasParam("scan_duration")) ROS_WARN("Used default parameter for scan_duration");
 			nh.param("scan_duration", scan_duration, 0.025); //no info about that in SICK-docu, but 0.025 is believable and looks good in rviz

--- a/cob_undercarriage_ctrl/ros/src/cob_undercarriage_ctrl.cpp
+++ b/cob_undercarriage_ctrl/ros/src/cob_undercarriage_ctrl.cpp
@@ -669,8 +669,8 @@ void NodeClass::UpdateOdometry()
     geometry_msgs::TransformStamped odom_tf;
     // compose header
     odom_tf.header.stamp = joint_state_odom_stamp_;
-    odom_tf.header.frame_id = "/odom_combined";
-    odom_tf.child_frame_id = "/base_footprint";
+    odom_tf.header.frame_id = "odom_combined";
+    odom_tf.child_frame_id = "base_footprint";
     // compose data container
     odom_tf.transform.translation.x = x_rob_m_;
     odom_tf.transform.translation.y = y_rob_m_;
@@ -685,8 +685,8 @@ void NodeClass::UpdateOdometry()
   nav_msgs::Odometry odom_top;
   // compose header
   odom_top.header.stamp = joint_state_odom_stamp_;
-  odom_top.header.frame_id = "/odom_combined";
-  odom_top.child_frame_id = "/base_footprint";
+  odom_top.header.frame_id = "odom_combined";
+  odom_top.child_frame_id = "base_footprint";
   // compose pose of robot
   odom_top.pose.pose.position.x = x_rob_m_;
   odom_top.pose.pose.position.y = y_rob_m_;


### PR DESCRIPTION
Fixes issues resulting from publishing a tf tranformation with frame ids that start with a slash character. Specifically, it solves the problem of cartographer_ros crashing with

> F0516 01:49:25.690616   949 sensor_bridge.cc:33] Check failed: frame_id[0] != '/' ('/' vs. '/') The frame_id /base_footprint should not start with a /. See 1.7 in http://wiki.ros.org/tf2/Migration.