### PR TITLE
use default libvlc configuration for noetic

### DIFF
--- a/cob_mimic/src/mimic_node.cpp
+++ b/cob_mimic/src/mimic_node.cpp
@@ -14,6 +14,7 @@
  */
 
 #include <ros/ros.h>
+#include <ros/common.h>
 #include <ros/package.h>
 #include <actionlib/server/simple_action_server.h>
 #include <diagnostic_updater/diagnostic_updater.h>
@@ -82,17 +83,21 @@ public:
 
         char const *argv[] =
         {
-            "--ignore-config",
-            "--mouse-hide-timeout=0",
-            "-q",
-            "--no-osd",
-            "-L",
-            "--one-instance",
-            "--playlist-enqueue",
-            "--no-video-title-show",
-            "--no-skip-frames",
-            "--no-audio",
-            "--vout=glx,none"
+            #if ROS_VERSION_MINIMUM(1, 15, 0) // ros noetic is 1.15.x
+                //ToDo: find correct settings for focal
+            #else
+                "--ignore-config",
+                "--mouse-hide-timeout=0",
+                "-q",
+                "--no-osd",
+                "-L",
+                "--one-instance",
+                "--playlist-enqueue",
+                "--no-video-title-show",
+                "--no-skip-frames",
+                "--no-audio",
+                "--vout=glx,none"
+            #endif
         };
         int argc = sizeof( argv ) / sizeof( *argv );
 


### PR DESCRIPTION
under ROS Noetic/Ubuntu Focal, the vlc did not open at all and the mimic node instantly exits

the default config is a quick-fix and at least allows to create a libvlc instance - however, the configs are not optimal and need further tuning

@benmaidel do you have any insights into the libvlc difference between the kinetic and the noetic version?