### PR TITLE
ROS_PYTHON_VERSION conditional dependency for `python-tk` and `python-numpy`

### DIFF
--- a/cob_bms_driver/package.xml
+++ b/cob_bms_driver/package.xml
@@ -23,7 +23,8 @@
 
   <exec_depend>cob_msgs</exec_depend>
   <exec_depend>cob_srvs</exec_depend>
-  <exec_depend>python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
   <exec_depend>rospy</exec_depend>
 
 </package>

--- a/cob_bms_driver/package.xml
+++ b/cob_bms_driver/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>cob_bms_driver</name>
   <version>0.7.5</version>
   <description>
@@ -8,10 +11,11 @@
 
   <maintainer email="felixmessmer@gmail.com">Felix Messmer</maintainer>
   <maintainer email="florian.weisshardt@ipa.fraunhofer.de">Florian Weisshardt</maintainer>
-  <author email="mig-mc@ipa.fhg.de">mig-mc</author>
-  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 
   <license>Apache 2.0</license>
+
+  <author email="mig-mc@ipa.fhg.de">mig-mc</author>
+  <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/cob_voltage_control/package.xml
+++ b/cob_voltage_control/package.xml
@@ -25,7 +25,8 @@
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-matplotlib</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-matplotlib</exec_depend>
-  <exec_depend>python-tk</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-tk</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-tk</exec_depend>
   <exec_depend>rospy</exec_depend>
 
 </package>


### PR DESCRIPTION
Introspecting Python 2 dependencies in ROS Noetic, found that this package depends on `python-tk` and `python-numpy` instead of its python3 counterpart.

This PR makes the dependency conditional on the ROS_PYTHON_VERSION.
SImilar to https://github.com/ipa320/cob_command_tools/pull/302

This is a semi-automated PR that has not been tested