### PR TITLE
[cob_light] more info in error case

### DIFF
--- a/cob_light/ros/src/cob_light.cpp
+++ b/cob_light/ros/src/cob_light.cpp
@@ -295,7 +295,7 @@ public:
                     p_colorO->setColorMulti(colors);
                   }
                   else
-                    ROS_ERROR_STREAM("More colors given in ColorRGBAArray then driver is configured to. num leds: "<<_num_leds);
+                    ROS_ERROR_STREAM("More colors given in ColorRGBAArray ("<<color.colors.size()<<") then driver is configured ("<<p_colorO->getNumLeds()<<"). num leds: "<<_num_leds);
               }
               else
               {


### PR DESCRIPTION
ref https://github.com/mojin-robotics/bmw/pull/224#pullrequestreview-1013863980
```
[ERROR] [1655826811.090691846]: /light_torso(topicCallback): More colors given in ColorRGBAArray then driver is configured to. num leds: 77
```
did not include the num_leds in the topic....now it does:
```
[ERROR] [1655830534.038846095]: /light_torso(topicCallback): More colors given in ColorRGBAArray (81) then driver is configured (77). num leds: 77
```