### PR TITLE
Fix power consumption of fake BMS

### DIFF
--- a/cob_bms_driver/src/fake_bms.py
+++ b/cob_bms_driver/src/fake_bms.py
@@ -80,7 +80,6 @@ class FakeBMS(object):
     def timer_consume_power_cb(self, event):
         # emulate the battery usage based on the current values
         self._remaining_capacity += (self._current/self._poll_frequency)/3600.0
-        self._remaining_capacity = round(self._remaining_capacity,3)
         if self._remaining_capacity <= 0.0:
             self._remaining_capacity = 0.0
         if self._remaining_capacity >= self._full_charge_capacity:

--- a/cob_bms_driver/src/fake_bms.py
+++ b/cob_bms_driver/src/fake_bms.py
@@ -66,14 +66,14 @@ class FakeBMS(object):
         stat.add("current[A]", self._current)
         stat.add("voltage[V]", self._voltage)
         stat.add("temperature[Celsius]", self._temperature)
-        stat.add("remaining_capacity[Ah]", self._remaining_capacity)
+        stat.add("remaining_capacity[Ah]", round(self._remaining_capacity, 3))
         stat.add("full_charge_capacity[Ah]", self._full_charge_capacity)
         return stat
 
     def timer_cb(self, event):
         self._pub_voltage.publish(self._voltage)
         self._pub_current.publish(self._current)
-        self._pub_remaining_capacity.publish(self._remaining_capacity)
+        self._pub_remaining_capacity.publish(round(self._remaining_capacity, 3))
         self._pub_full_charge_capacity.publish(self._full_charge_capacity)
         self._pub_temparature.publish(self._temperature)
 


### PR DESCRIPTION
The rounding of the remaining capacity may lead to no fake power consumption at all. This is e.g. the case for the default parameters of `self._current = -8.0` and `self._poll_frequency = 20.0`:

```
self._remaining_capacity += (self._current/self._poll_frequency)/3600.0
self._remaining_capacity = round(self._remaining_capacity,3)
```
With an initial `self._remaining_capacity` of `60.0` we have the following result:
```
self._remaining_capacity = 60.0 + (-8.0 / 20.0) / 3600.0 = 59.99988888888889
self._remaining_capacity = round(59.99988888888889, 3) = 60.0