### PR TITLE
fix(cob_scan_unifier): fix handeling of negative angle_increments

### DIFF
--- a/cob_scan_unifier/src/scan_unifier_node.cpp
+++ b/cob_scan_unifier/src/scan_unifier_node.cpp
@@ -254,7 +254,7 @@ bool ScanUnifierNode::unifyLaserScans(const std::vector<sensor_msgs::LaserScan::
     ROS_DEBUG("Creating message header");
     unified_scan.header = current_scans.front()->header;
     unified_scan.header.frame_id = frame_;
-    unified_scan.angle_increment = current_scans.front()->angle_increment;
+    unified_scan.angle_increment = std::abs(current_scans.front()->angle_increment);
     unified_scan.angle_min = -M_PI + unified_scan.angle_increment*0.01;
     unified_scan.angle_max =  M_PI - unified_scan.angle_increment*0.01;
     unified_scan.time_increment = current_scans.front()->time_increment;


### PR DESCRIPTION
laser scanners that are upside down often have negative angle_increments (and also angle_max < angle_min).

Since we use angle_max=M_PI angle_min=-M_PI in the unified scan here, we can't just copy the angle increment but need to use the absolute value of angle_increments

 - fixes dying of scan_unifier for negative angle_increments

